### PR TITLE
Remove explicit setting of tracking category controller name

### DIFF
--- a/lib/xeroizer/models/tracking_category.rb
+++ b/lib/xeroizer/models/tracking_category.rb
@@ -3,7 +3,6 @@ module Xeroizer
     
     class TrackingCategoryModel < BaseModel
       
-      set_api_controller_name 'TrackingCategory'
       set_permissions :read
                   
     end


### PR DESCRIPTION
The TrackingCategory model explicitly sets the incorrect endpoint name, the correct endpoint is https://api.xero.com/api.xro/2.0/TrackingCategories, which the default pluralisation rule will set correctly.
