### PR TITLE
Delegate authorize_from_access

### DIFF
--- a/lib/xeroizer/public_application.rb
+++ b/lib/xeroizer/public_application.rb
@@ -2,7 +2,7 @@ module Xeroizer
   class PublicApplication < GenericApplication
     
     extend Forwardable
-    def_delegators :client, :request_token, :authorize_from_request
+    def_delegators :client, :request_token, :authorize_from_request, :authorize_from_access
 
     public
     


### PR DESCRIPTION
Xeroizer::PublicApplication needs to delegate authorize_from_access to :client.  Without this, the PublicApplication examples do not work.
