### PR TITLE
Return sensible default values for nil attributes

### DIFF
--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -38,8 +38,8 @@ module Xeroizer
         # Helper methods used to define the fields this model has.
         def string(field_name, options = {});     define_simple_attribute(field_name, :string, options); end
         def boolean(field_name, options = {});    define_simple_attribute(field_name, :boolean, options); end
-        def integer(field_name, options = {});    define_simple_attribute(field_name, :integer, options); end
-        def decimal(field_name, options = {});    define_simple_attribute(field_name, :decimal, options); end
+        def integer(field_name, options = {});    define_simple_attribute(field_name, :integer, options, 0); end
+        def decimal(field_name, options = {});    define_simple_attribute(field_name, :decimal, options, 0.0); end
         def date(field_name, options = {});       define_simple_attribute(field_name, :date, options); end
         def datetime(field_name, options = {});   define_simple_attribute(field_name, :datetime, options); end
         
@@ -56,7 +56,7 @@ module Xeroizer
         #   :api_name => allows the API name to be specified if it can't be properly converted from camelize.
         #   :model_name => allows class used for children to be different from it's ndoe name in the XML.
         #   :type => type of field
-        def define_simple_attribute(field_name, field_type, options)
+        def define_simple_attribute(field_name, field_type, options, value_if_nil = nil)
           self.fields ||= {}
           
           internal_field_name = options[:internal_name] || field_name
@@ -66,7 +66,7 @@ module Xeroizer
             :type           => field_type
           })
           define_method internal_field_name do 
-            @attributes[field_name]
+            @attributes[field_name] || value_if_nil
           end
           define_method "#{internal_field_name}=".to_sym do | value | 
             @attributes[field_name] = value

--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -73,7 +73,8 @@ module Xeroizer
         end
         
         def define_association_attribute(field_name, internal_field_name, association_type, options)
-          define_simple_attribute(field_name, association_type, options)
+          value_if_nil = (association_type == :has_many) ? [] : nil
+          define_simple_attribute(field_name, association_type, options, value_if_nil)
 
           # Override reader for this association if this association belongs
           # to a summary-typed record. This will automatically attempt to download
@@ -81,7 +82,7 @@ module Xeroizer
           if list_contains_summary_only?
             define_method internal_field_name do
               download_complete_record! unless new_record? || complete_record_downloaded?
-              @attributes[field_name]
+              @attributes[field_name] || value_if_nil
             end
           end
         end


### PR DESCRIPTION
Currently we have to do a lot of extra checking around some values, e.g. we have to do things like this to ensure array values are not nil before accessing methods on them:

```
if invoice.payments
    invoice.payments.each do |payment|
        ...
    end
end
```

This patch returns empty arrays for `:has_many` relationships, so the wrapping `if` above is not necessary.  Also returns 0 for numeric values by default.
