### PR TITLE
Add offset header parameter

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -40,6 +40,7 @@ module Xeroizer
                                   when Hash     then parse_where_hash(options[:where])
                                 end
             end
+            params[:offset] = options[:offset] if options[:offset]
             params
           end
         


### PR DESCRIPTION
Allows offset header to be used when retrieving more than 100 journals as per API.
