### PR TITLE
Accept empty constructor

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -36,7 +36,7 @@ module Xeroizer
       
       public
       
-        def initialize(parent)
+        def initialize(parent = nil)
           @parent = parent
           @attributes = {}
         end


### PR DESCRIPTION
This is to allow us to test Xeroizer objects with Factory Girl, which can only initialize objects with an empty constructor.  Would really appreciate it if this one got in, otherwise we will need to rework our testing.  This does not appear to impact the operation of our production app in any way.
