### PR TITLE
Partner application openssl and doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Authentication occcurs in 3 steps:
 						"/path/to/privatekey.pem",
 						"/path/to/entrust-cert.pem",
 						"/path/to/entrust-private-nopass.pem",
-						ENTRUST_PRIVATE_KEY_PASSWORD
+						:password => ENTRUST_PRIVATE_KEY_PASSWORD
 						)
 	
 	# 1. Get a RequestToken from Xero. The :oauth_url is the URL the user will be redirected to

--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -25,7 +25,7 @@ module Xeroizer
           :signature_method => 'RSA-SHA1',
           :private_key_file => path_to_private_key,
           :ssl_client_cert => OpenSSL::X509::Certificate.new(File.read(path_to_ssl_client_cert)),
-          :ssl_client_key => OpenSSL::PKey::RSA.new(path_to_ssl_client_key)
+          :ssl_client_key => OpenSSL::PKey::RSA.new(File.read(path_to_ssl_client_key))
         )
         super(consumer_key, consumer_secret, options)
         


### PR DESCRIPTION
Two suggested changes here.  The creation of a PKey requires a file read as opposed to a file path, and a documentation fix indicating the need to pass in a hash for the password so as to allow options to be merged subsequently in the PartnerApplication class.
