### PR TITLE
Implement Xeroizer::Record::Base#inspect

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -83,6 +83,13 @@ module Xeroizer
           end
           true
         end
+
+        def inspect
+          attribute_string = self.attributes.collect do |attr, value|
+            "#{attr.inspect}: #{value.inspect}"
+          end.join(", ")
+          "#<#{self.class} #{attribute_string}>"
+        end
                 
       protected
       


### PR DESCRIPTION
Only show the current instance attributes on inspect, otherwise
the parent object, which contains references to all objects fetched
in the current session, is displayed.
