### PR TITLE
Pluralize reports controller name

### DIFF
--- a/lib/xeroizer/report/factory.rb
+++ b/lib/xeroizer/report/factory.rb
@@ -29,7 +29,7 @@ module Xeroizer
         end
       
         def api_controller_name
-          "Report/#{report_type}"
+          "Reports/#{report_type}"
         end
 
         def klass

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,7 @@ module TestHelper
   end
   
   def mock_report_api(report_type)
-    @client.stubs(:http_get).with { | client, url, params | url =~ /Report\/#{report_type}$/ }.returns(get_report_xml(report_type))
+    @client.stubs(:http_get).with { | client, url, params | url =~ /Reports\/#{report_type}$/ }.returns(get_report_xml(report_type))
   end
     
 end

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -17,7 +17,7 @@ class FactoryTest < Test::Unit::TestCase
         :BudgetSummary, :ExecutiveSummary, :ProfitAndLoss, :TrialBalance
       ].each do | report_type |
         report_factory = @client.send(report_type)
-        assert_equal("Report/#{report_type}", report_factory.api_controller_name)
+        assert_equal("Reports/#{report_type}", report_factory.api_controller_name)
       end
     end
     


### PR DESCRIPTION
Although the singular works, according to the documentation at
http://blog.xero.com/developer/api/Reports/ the endpoint prefix is
Reports, not Report.
