### PR TITLE
Call method for calculated fields in to_xml

### DIFF
--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -58,10 +58,9 @@ module Xeroizer
           def to_xml(b = Builder::XmlMarkup.new(:indent => 2))
             b.tag!(parent.class.xml_node_name || parent.model_name) { 
               attributes.each do | key, value |
-                unless value.nil?
-                  field = self.class.fields[key]
-                  xml_value_from_field(b, field, value)
-                end
+                field = self.class.fields[key]
+                value = self.send(key) if field[:calculated]
+                xml_value_from_field(b, field, value) unless value.nil?
               end
             }
           end


### PR DESCRIPTION
I ran into this issue when I created a DRAFT Invoice with no line items, then added a line item using add_line_item and then tried to save the invoice.  I kept getting a Xero validation error because the invoice total didn't match the total of the line items.  The invoice total was always coming back as 0, even though the line_item I added was more than 0.  When xeroizer called invoice.to_xml it was using invoice.attributes[:total], which was still set to 0, instead of calculating the invoice total after the line item was added.  This patch should ensure that any calculated fields are always calculated dynamically when to_xml is called.
