### PR TITLE
LineItem#line_amount should be rounded to 2dp

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -35,9 +35,7 @@ module Xeroizer
       # Calculate the line_total (if there is a quantity and unit_amount).
       # Description-only lines have been allowed since Xero V2.09.
       def line_amount
-        unless quantity.nil? && unit_amount.nil?
-          quantity * unit_amount
-        end
+        BigDecimal((quantity * unit_amount).to_s).round(2) if quantity && unit_amount
       end
       
     end

--- a/test/unit/models/invoice_test.rb
+++ b/test/unit/models/invoice_test.rb
@@ -8,7 +8,23 @@ class InvoiceTest < Test::Unit::TestCase
     mock_api('Invoices')
     @invoice = @client.Invoice.first
   end
-  
+
+  def build_valid_authorised_invoice
+    @client.Invoice.build({
+      :type => "ACCREC",
+      :contact => { :name => "ABC Limited" },
+      :status => "AUTHORISED",
+      :date => Date.today,
+      :due_date => Date.today,
+      :line_items => [{
+        :description => "Consulting services as agreed",
+        :quantity => 0.005,
+        :unit_amount => 1,
+        :account_code => 200
+      }]
+    })
+  end
+
   context "invoice types" do
     
     should "have helpers to determine invoice type" do
@@ -45,7 +61,7 @@ class InvoiceTest < Test::Unit::TestCase
         assert_equal(invoice.attributes[:total], invoice.total)
       end
     end
-    
+
   end
   
   context "invoice validations" do
@@ -65,20 +81,17 @@ class InvoiceTest < Test::Unit::TestCase
     end
 
     should "build a valid AUTHORISED invoice with complete attributes" do
-      invoice = @client.Invoice.build({
-        :type => "ACCREC",
-        :contact => { :name => "ABC Limited" },
-        :status => "AUTHORISED",
-        :date => Date.today,
-        :due_date => Date.today,
-        :line_items => [{
-          :description => "Consulting services as agreed",
-          :quantity => 5,
-          :unit_amount => 120,
-          :account_code => 200
-        }]
-      })
+      invoice = build_valid_authorised_invoice
       assert_equal(true, invoice.valid?)
+    end
+
+  end
+
+  context "line items" do
+
+    should  "round line item amounts to two decimal places" do
+      invoice = build_valid_authorised_invoice
+      assert_equal(0.01, invoice.line_items.first.line_amount)
     end
 
   end


### PR DESCRIPTION
From my testing this duplicates what Xero does when you add line items through the web UI.

I found the bug because I was getting this error in production:

Xeroizer::ApiException: ValidationException: A validation exception occurred Generated by the following XML:

``` xml
<ApiException xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <ErrorNumber>10</ErrorNumber>
  <Type>ValidationException</Type>
  <Message>A validation exception occurred</Message>
  <Elements> <DataContractBase xsi:type="Invoice">
  <ValidationErrors>
    <ValidationError>
      <Message>The invoice total does not equal the sum of the lines.</Message>
    </ValidationError>
  </ValidationErrors>
```
