### PR TITLE
Allow records to be created (built and saved) and updated in one step (pass hash of updated attributes and saved)

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -53,6 +53,13 @@ module Xeroizer
         def []=(attribute, value)
           self.send("#{attribute}=".to_sym, value)
         end
+
+        def update_attributes(attributes = {})
+          attributes.each do | key, value |
+            self.send("#{key}=".to_sym, value)
+          end
+          save
+        end
         
         def new_record?
           id.nil?

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -88,6 +88,11 @@ module Xeroizer
         def build(attributes = {})
           model_class.build(attributes, self)
         end
+
+        # Create (build and save) a record with attributes set to the value of attributes.
+        def create(attributes = {})
+          build(attributes).tap { |resource| resource.save }
+        end
         
         # Retreive full record list for this model. 
         def all(options = {})


### PR DESCRIPTION
Adds ActiveRecord style `create` and `update_attributes` methods.

Instead of:

``` ruby
contact = xero.Contact.build(:name => 'WR Inc.', :first_name => 'Wayne', :last_name => 'Robinson')
contact.save
```

can do one-liner:

``` ruby
contact = xero.Contact.create(:name => 'WR Inc.', :first_name => 'Wayne', :last_name => 'Robinson')
```

Like AR, the resulting object is returned whether the object was saved successfully or not, so that you can check it with `contact.valid?` and see its errors with `contact.errors`.

And to update, instead of:

``` ruby
contact.email_address = "wayne@example.com"
contact.default_currency = "NZD"
contact.save
```

you can do the one-liner:

``` ruby
contact.update_attributes(:email_address => "wayne@example.com", :default_currency => "NZD")
```
