### PR TITLE
Allow setting attributes via hash _without_ saving as well

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -54,10 +54,15 @@ module Xeroizer
           self.send("#{attribute}=".to_sym, value)
         end
 
-        def update_attributes(attributes = {})
-          attributes.each do | key, value |
+        def attributes=(new_attributes)
+          return unless new_attributes.is_a?(Hash)
+          new_attributes.each do | key, value |
             self.send("#{key}=".to_sym, value)
           end
+        end
+
+        def update_attributes(attributes)
+          self.attributes = attributes
           save
         end
         


### PR DESCRIPTION
As a followup to https://github.com/waynerobinson/xeroizer/pull/44, allow setting attributes with a hash via `attributes=` as well _without_ the automatic save of `update_attributes`.
