### PR TITLE
AccessToken Renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Renewal of an access token requires knowledge of the previous access token gener
 client.renew_access_token
 
 # If you are renewing from stored token/session details.
-client.renew_access_token(access_key, access_secret, session_handle)
+client.renew_access_token(access_token, access_secret, session_handle)
 ```
 
 This will invalidate the previous token and refresh the `access_key` and `access_secret` as specified in the


### PR DESCRIPTION
I am not sure if this is specifically to do with the Partner Application renewing the Access Token as per `client.renew_access_token(access_key, access_secret, session_handle)` but I found that this would not work, but passing the access_token would work eg `client.renew_access_token(access_token, access_secret, session_handle)`

I was scratching my head for ages, but upon changing access_key to access_token which would pass the token in, that seemed to work.

Can anyone else review to see if this is correct? That way worked for me through the Partner Application.
