### PR TITLE
Added Reference to Bank Transactions

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -19,7 +19,7 @@ module Xeroizer
 
       date :updated_date_utc, :api_name => "UpdatedDateUTC"
       date :fully_paid_on_date
-      string :reference, :api_name => "Reference"
+      string :reference
       string :bank_transaction_id, :api_name => "BankTransactionID"
       boolean :is_reconciled
 


### PR DESCRIPTION
I noticed that Xeroizer isn't pulling in bank transaction References, so I've added this to the model. Without the Reference there is no canonical ID linked to bank transactions (BankTransactionID changes with every transaction update).

I'm not sure if I have to add anything else? I'm just getting them, not sending them, and I am quite new to this gem. Just let me know if I should make any changes.
