### PR TITLE
Enables TaxRate status field

### DIFF
--- a/lib/xeroizer/models/tax_rate.rb
+++ b/lib/xeroizer/models/tax_rate.rb
@@ -11,6 +11,7 @@ module Xeroizer
       
       string  :name
       string  :tax_type
+      string  :status
       boolean :can_apply_to_assets
       boolean :can_apply_to_equity
       boolean :can_apply_to_expenses


### PR DESCRIPTION
The reference manual doesn't mention it
(http://blog.xero.com/developer/api/Tax%20Rates/) but the API previewer
tells you whether the TaxRate is ACTIVE or DELETED.

```
<TaxRate>
  <Name>My Rate</Name>
  <TaxType>TAX003</TaxType>
  <CanApplyToAssets>true</CanApplyToAssets>
  <CanApplyToEquity>true</CanApplyToEquity>
  <CanApplyToExpenses>true</CanApplyToExpenses>
  <CanApplyToLiabilities>true</CanApplyToLiabilities>
  <CanApplyToRevenue>true</CanApplyToRevenue>
  <DisplayTaxRate>3.2000</DisplayTaxRate>
  <EffectiveRate>3.2000</EffectiveRate>
  <Status>DELETED</Status>
</TaxRate>
```

This is untested at the moment. I can't quite figure out how to setup the xero account in order to run the tests against it. I used this in the console, and it worked fine though.

``` ruby
> client.TaxRate.all.first.status
=> "ACTIVE"

> client.TaxRate.all.where(:status => "ACTIVE").count
=> 6
```
