### PR TITLE
Add discount_rate to line_items and include in calculations.

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -18,6 +18,7 @@ module Xeroizer
       string  :tax_type
       decimal :tax_amount
       decimal :line_amount, :calculated => true
+      decimal :discount_rate
       
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
       
@@ -31,7 +32,7 @@ module Xeroizer
       def line_amount(summary_only = false)
         return attributes[:line_amount] if summary_only || @line_amount_set
         
-        BigDecimal((quantity * unit_amount).to_s).round(2) if quantity && unit_amount
+        BigDecimal((quantity * unit_amount * ((100.0 - discount_rate)/100.0)).to_s).round(2) if quantity && unit_amount
       end
       
     end


### PR DESCRIPTION
Fixes #56.

@waynerobinson  this isn't perfect yet, particularly it's untested, but I wanted to open it to start the discussion anyway.

It's not clear to me why we manually calculate the line item amount, when xero appears to return it from the API. [line_item.rb/33](https://github.com/latentflip/xeroizer/commit/784ff8fa0b8135d7a601dc3d3e978815c5f8ae8a#L0L33) Is there a reason why we recalculate it?
