### PR TITLE
Bank transaction list only contains summary

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -14,6 +14,8 @@ module Xeroizer
       end
 
       set_primary_key :bank_transaction_id
+      list_contains_summary_only true
+
       string :type
       date :date
 


### PR DESCRIPTION
Bank transactions have line items too, and should be marked as summary only.
