### PR TITLE
Fix ordering

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -17,7 +17,8 @@ module Xeroizer
           def parse_params(options)
             params = {}
             params[:ModifiedAfter]  = options[:modified_since] if options[:modified_since]          
-            params[:OrderBy]        = options[:order] if options[:order]
+            params[:order]        = options[:order] if options[:order]
+
             if options[:where]
               params[:where] =  case options[:where]
                                   when String   then options[:where] 


### PR DESCRIPTION
Xero's ordering parameter is now "order" not "orderBy".
