### PR TITLE
Add the Nokogiri XML object to ApiExceptions.

### DIFF
--- a/lib/xeroizer/exceptions.rb
+++ b/lib/xeroizer/exceptions.rb
@@ -1,12 +1,13 @@
 module Xeroizer
   class ApiException < StandardError
     
-    attr_reader :type, :message, :xml, :request_body
+    attr_reader :type, :message, :xml, :parsed_xml, :request_body
     
-    def initialize(type, message, xml, request_body)
+    def initialize(type, message, xml, parsed_xml, request_body)
       @type         = type
       @message      = message
       @xml          = xml
+      @parsed_xml   = parsed_xml
       @request_body = request_body
     end
     

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -140,9 +140,10 @@ module Xeroizer
         
         if doc && doc.root && doc.root.name == "ApiException"
 
-          raise ApiException.new(doc.root.xpath("Type").text, 
-                                 doc.root.xpath("Message").text, 
+          raise ApiException.new(doc.root.xpath("Type").text,
+                                 doc.root.xpath("Message").text,
                                  raw_response,
+                                 doc,
                                  request_body)
 
         else


### PR DESCRIPTION
Saves us the trouble of parsing the XML more than once when we need to get the ValidationErrors out of it.
