### PR TITLE
Correct bogus xpath specification for ValidationErrors.

### DIFF
--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -182,7 +182,7 @@ module Xeroizer
             new_record = model_class.build_from_node(element, self)
             if element.attribute('status').try(:value) == 'ERROR'
               new_record.errors = []
-              element.xpath('//ValidationError').each do |err|
+              element.xpath('.//ValidationError').each do |err|
                 new_record.errors << err.text.gsub(/^\s+/, '').gsub(/\s+$/, '')
               end
             end


### PR DESCRIPTION
This one's all my fault. Forgot the dot in the xpath for extracting errors, so it was grabbing all the errors in the document instead of just the children of the current node. Sorry!
