### PR TITLE
Add error messages to records that batch_save can't sync.

### DIFF
--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -154,6 +154,7 @@ module Xeroizer
               response.response_items.each_with_index do |record, i|
                 if record and record.is_a?(model_class)
                   records[i].attributes = record.attributes
+                  records[i].errors = record.errors
                   records[i].saved!
                 end
               end


### PR DESCRIPTION
Copy error messages from Xero's responses into the user's Xeroizer::Record models.
