### PR TITLE
Chunk large batch saves to prevent timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ end
 `batch_save` will issue one PUT request for every 2,000 unsaved records built within its block, and one
 POST request for evert 2,000 existing records that have been altered within its block. If any of the
 unsaved records aren't valid, it'll return `false` before sending anything across the wire;
-otherwise, it returns `true`.
+otherwise, it returns `true`. `batch_save` takes one optional argument: the number of records to
+create/update per request. (Defaults to 2,000.)
 
 ### Errors
 

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -19,7 +19,7 @@ module Xeroizer
       class_inheritable_attributes :optional_xml_root_name
       class_inheritable_attributes :xml_node_name
 
-      MAX_RECORDS_PER_BATCH_SAVE = 2000
+      DEFAULT_RECORDS_PER_BATCH_SAVE = 2000
 
       include BaseModelHttpProxy
 
@@ -140,7 +140,7 @@ module Xeroizer
           result
         end
 
-        def batch_save
+        def batch_save(chunk_size = DEFAULT_RECORDS_PER_BATCH_SAVE)
           @objects = {}
           @allow_batch_operations = true
 
@@ -151,7 +151,7 @@ module Xeroizer
             return false unless objects.all?(&:valid?)
             actions = objects.group_by {|o| o.new_record? ? :http_put : :http_post }
             actions.each_pair do |http_method, records|
-              records.each_slice(MAX_RECORDS_PER_BATCH_SAVE) do |some_records|
+              records.each_slice(chunk_size) do |some_records|
                 request = to_bulk_xml(some_records)
                 response = parse_response(self.send(http_method, request, {:summarizeErrors => false}))
                 response.response_items.each_with_index do |record, i|


### PR DESCRIPTION
Turns out that, while batch saves are great at reducing the number of API calls you make, Xero's not so great at handling them once you get into "several thousand records per update" territory. We're getting lots of timeout errors syncing a >10,000-contact data set, and this seems to relieve them.

Basically, we just break a batch_save into N chunks of 2,000 records and make N requests.
