### PR TITLE
Rails 4 no longer includes ActiveSupport::Memoizable

### DIFF
--- a/lib/xeroizer.rb
+++ b/lib/xeroizer.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'date'
 require 'forwardable'
 require 'active_support/inflector'
-require 'active_support/memoizable'
 # require "active_support/core_ext"
 require 'oauth'
 require 'oauth/signature/rsa/sha1'


### PR DESCRIPTION
Without this pull request it is not possible to start the server on rails 4
