### PR TITLE
Added Invoice#approve - marks an invoice as approved

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -180,6 +180,11 @@ module Xeroizer
         def void!
           delete_or_void_invoice!('VOIDED')
         end
+        
+        # Approve a draft invoice
+        def approve!
+          delete_or_void_invoice!('AUTHORISED')
+        end
 
       protected
 


### PR DESCRIPTION
I've added an approve! method to Invoice

The delete_or_void_invoice method name no longer makes sense but I've left it to you to decide best what that should now be called.
