### PR TITLE
batch_save should return false on server-side errors.

### DIFF
--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -159,7 +159,7 @@ module Xeroizer
                   if record and record.is_a?(model_class)
                     some_records[i].attributes = record.attributes
                     some_records[i].errors = record.errors
-                    no_errors = record.errors.empty? if no_errors
+                    no_errors = record.errors.nil? || record.errors.empty? if no_errors
                     some_records[i].saved!
                   end
                 end


### PR DESCRIPTION
At present, `batch_save` only bails on client-side errors from invalid models. Server-side errors, like those caused by editing outside document lock dates, don't cause it to return false. Obviously, this sucks. (See issue #92.)
