### PR TITLE
Adding Currency Rate to invoices

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -65,7 +65,7 @@ module Xeroizer
       decimal      :amount_credited
       datetime_utc :updated_date_utc, :api_name => 'UpdatedDateUTC'
       string       :currency_code
-      string       :currency_rate
+      decimal      :currency_rate
       datetime     :fully_paid_on_date
       boolean      :sent_to_contact
 


### PR DESCRIPTION
Wayne,
I added this one line to invoice.rb so I could set a Currency Rate manually instead of relying on xe.com rate.
It might make sense to added it to the other modules that make reference to CurrencyCode.

Thanks!
