### PR TITLE
adding a :logger option in the xero application initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,17 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
                                          :rate_limit_sleep => 2)
 ```
 
+Logging
+---------------
+
+You can add an optional paramater to the Xeroizer Application initialization, to pass a logger object that will need to respond_to :info. For example, in a rails app:
+
+```ruby
+XeroLogger = Logger.new('log/xero.log', 'weekly')
+client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
+                                         YOUR_OAUTH_CONSUMER_SECRET,
+                                         :logger => XeroLogger)
+```
 
 ### Contributors
 Xeroizer was inspired by the https://github.com/tlconnor/xero_gateway gem created by Tim Connor 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -49,6 +49,7 @@ module Xeroizer
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
         @client   = OAuth.new(consumer_key, consumer_secret, options)
+        @logger = options[:logger] || false
       end
 
   end

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -86,7 +86,7 @@ module Xeroizer
 
         begin
           attempts += 1
-          logger.info("\n== [#{Time.now.to_s}] XeroGateway Request: #{method.to_s.upcase} #{uri.request_uri} ") if self.logger
+          logger.info("XeroGateway Request: #{method.to_s.upcase} #{uri.request_uri}") if self.logger
 
           raw_body = params.delete(:raw_body) ? body : {:xml => body}
 
@@ -97,10 +97,9 @@ module Xeroizer
           end
 
           if self.logger
-            logger.info("== [#{Time.now.to_s}] XeroGateway Response (#{response.code})")
-
+            logger.info("XeroGateway Response (#{response.code})")
             unless response.code.to_i == 200
-              logger.info("== #{uri.request_uri} Response Body \n\n #{response.plain_body} \n == End Response Body")
+              logger.info("#{uri.request_uri}\n== Response Body\n\n#{response.plain_body}\n== End Response Body")
             end
           end
 
@@ -121,7 +120,7 @@ module Xeroizer
         rescue Xeroizer::OAuth::RateLimitExceeded
           if self.rate_limit_sleep
             raise if attempts > rate_limit_max_attempts
-            logger.info("== Rate limit exceeded, retrying") if self.logger
+            logger.info("Rate limit exceeded, retrying") if self.logger
             sleep_for(self.rate_limit_sleep)
             retry
           else


### PR DESCRIPTION
I added in this patch a simple adding of the logger instance variable that was already there but not initialized. My changes in http.rb are about formatting, the Logger passed in options should be in charge of the timestamping imho, but you can disregard it.

I hope we could use various other log levels all over, especialy :debug, having a good logging really helps.
