### PR TITLE
Fixed saving as invoices raising "\xE2" from ASCII-8BIT to UTF-8

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -20,7 +20,7 @@ module Xeroizer
         def pdf(id, filename = nil)
           pdf_data = @application.http_get(@application.client, "#{url}/#{CGI.escape(id)}", :response => :pdf)
           if filename
-            File.open(filename, "w") { | fp | fp.write pdf_data }
+            File.open(filename, "wb") { | fp | fp.write pdf_data }
             nil
           else
             pdf_data


### PR DESCRIPTION
Saving an invoice PDF raises an error. The 'b' flag fixes it.
