### PR TITLE
Fix NameError for missing 'record' variable.

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -197,7 +197,7 @@ module Xeroizer
       protected
 
         def change_status!(new_status)
-          raise CannotChangeInvoiceStatus.new(record, new_status) unless self.payments.size == 0
+          raise CannotChangeInvoiceStatus.new(self, new_status) unless self.payments.size == 0
           self.status = new_status
           self.save
         end


### PR DESCRIPTION
Fixes unexpected NameError exception when you try to delete an invoice that's got payments on it.
