### PR TITLE
Switch back to using PUT when creating records

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -142,7 +142,7 @@ module Xeroizer
           request = to_xml
           log "[CREATE SENT] (#{__FILE__}:#{__LINE__}) #{request}"
           
-          response = parent.http_post(request)
+          response = parent.http_put(request)
           log "[CREATE RECEIVED] (#{__FILE__}:#{__LINE__}) #{response}"
           
           parse_save_response(response)


### PR DESCRIPTION
Xero doesn't use PUT the way it's defined in REST, but when we switched to using POST for creates it caused some issues for us at Harvest.

See http://developer.xero.com/documentation/getting-started/http-requests-and-responses/

> The HTTP PUT and POST methods are used for sending information to the API.
> 
> A PUT method will create new data in Xero, whereas a POST will either create new data or update existing data in Xero.

By using POST, it's possible to overwrite invoices that may have the same invoice number.  For example, say I have an existing invoice in Xero with invoice number "123".  If I try to PUT a new invoice with that same invoice number, Xero responds with a validation error.  If I POST a new invoice with that same invoice number it will "update" the existing invoice with the new data.

I know there was an issue related to the PUT method being used for creates: https://github.com/waynerobinson/xeroizer/issues/32, but it seems a bit heavy handed to change ALL creates in Xeroizer to use POST instead of PUT.  Do we still have the ManualJournal / OAuth issue?  I know you had commented in that Issue that it may be a problem with the OAuth gem:

> I'm not sure what is going on here and haven't had a chance to do my own testing on this at the moment. I know that XeroGateway is having similar problems so there might be a change to the OAuth gem that has broken this.

/cc @zmoazeni 
