### PR TITLE
Fixing Errors in Example Controller Doco

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class XeroSessionController < ApplicationController
 					:access_key => @xero_client.access_token.secret }
 															
 			session[:request_token] = nil
-            	session[:request_secret] = nil
+            session[:request_secret] = nil
 		end
 		
 		def destroy


### PR DESCRIPTION
:access_key => @xero_client.access_token.key should be :access_key => @xero_client.access_token.secret
