### PR TITLE
Add Xeroizer::GenericApplication.default_headers

### DIFF
--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -6,7 +6,7 @@ module Xeroizer
     include Http
     extend Record::ApplicationHelper
 
-    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts
+    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts, :default_headers
 
     extend Forwardable
     def_delegators :client, :access_token
@@ -51,6 +51,7 @@ module Xeroizer
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
         @client   = OAuth.new(consumer_key, consumer_secret, options)
         @logger = options[:logger] || false
+        @default_headers = options[:default_headers] || {}
       end
 
   end

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -55,7 +55,7 @@ module Xeroizer
       def http_request(client, method, url, body, params = {})
         # headers = {'Accept-Encoding' => 'gzip, deflate'}
 
-        headers = { 'charset' => 'utf-8' }
+        headers = self.default_headers.merge({ 'charset' => 'utf-8' })
 
         if method != :get
           headers['Content-Type'] ||= "application/x-www-form-urlencoded"

--- a/test/unit/generic_application_test.rb
+++ b/test/unit/generic_application_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class GenericApplicationTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @headers = {"User-Agent" => "Xeroizer/2.15.5"}
+    @client = Xeroizer::GenericApplication.new(CONSUMER_KEY, CONSUMER_SECRET, :default_headers => @headers)
+  end
+
+  context "initialization" do
+
+    should "pass default headers" do
+      assert_equal(@headers, @client.default_headers)
+    end
+
+  end
+
+end
+
+

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class HttpTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @headers = {"User-Agent" => "Xeroizer/2.15.5"}
+    @application = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET, :default_headers => @headers)
+  end
+
+  context "default_headers" do
+    should "recognize default_headers" do
+      Xeroizer::OAuth.any_instance.expects(:get).with("/test", has_entry(@headers)).returns(stub(:plain_body => "", :code => "200"))
+      @application.http_get(@application.client, "http://example.com/test")
+    end
+  end
+end
+


### PR DESCRIPTION
Add the ability to send custom headers with Xero API calls

This is what we're using:

``` ruby
Xeroizer::PartnerApplication.new(
  ENV["XERO_CONSUMER_KEY"],
  ENV["XERO_CONSUMER_SECRET"],
  "#{CERTS_DIR}/privatekey.pem",
  "#{CERTS_DIR}/entrust-cert.pem",
  "#{CERTS_DIR}/entrust-private-nopass.pem",
  default_headers: {
    'User-Agent' => "MyApp/1.4 Xeroizer/#{Xeroizer::VERSION}"
  }
)
```

This is a redo of #132 but from a git branch
