### PR TITLE
Unfreeze the gemspec's version string.

### DIFF
--- a/xeroizer.gemspec
+++ b/xeroizer.gemspec
@@ -5,7 +5,7 @@ require 'xeroizer/version'
 
 Gem::Specification.new do |s|
   s.name = "xeroizer"
-  s.version = Xeroizer::VERSION
+  s.version = Xeroizer::VERSION.dup
   s.date = "2013-07-04"
   s.authors = ["Wayne Robinson"]
   s.email = "wayne.robinson@gmail.com"


### PR DESCRIPTION
Avoids a "can't modify frozen String" error under older versions of Rubygems.

```
$ gem --version
1.8.28
$ bundle exec rake test
There was a RuntimeError while loading xeroizer.gemspec: 
can't modify frozen String from
  /Users/fimmtiu/xeroizer/xeroizer.gemspec:8:in `block in <main>'
```
