### PR TITLE
Fix setting the 'Class' attribute on Accounts.

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -29,7 +29,8 @@ module Xeroizer
         def build(attributes, parent)
           record = new(parent)
           attributes.each do | key, value |
-            record.send("#{key}=".to_sym, value)
+            attr = record.respond_to?("#{key}=") ? key : record.class.fields[key][:internal_name]
+            record.send("#{attr}=", value)
           end
           record
         end
@@ -65,7 +66,8 @@ module Xeroizer
           return unless new_attributes.is_a?(Hash)
           parent.mark_dirty(self) if parent
           new_attributes.each do | key, value |
-            self.send("#{key}=".to_sym, value)
+            attr = respond_to?("#{key}=") ? key : self.class.fields[key][:internal_name]
+            self.send("#{attr}=", value)
           end
         end
 


### PR DESCRIPTION
If you try to set the 'Class' attribute on an account, you'll get a NoMethodError about the method "class=" not existing. This patch will try the straight key name first, and if that fails, fall back to the field's internal name ('account_class', in this case).
