### PR TITLE
Don't use POST on endpoints that don't support it.

### DIFF
--- a/lib/xeroizer/models/account.rb
+++ b/lib/xeroizer/models/account.rb
@@ -5,6 +5,10 @@ module Xeroizer
 
       set_permissions :read, :write
 
+      # The Accounts endpoint doesn't support the POST method yet.
+      def create_method
+        :http_put
+      end
     end
 
     class Account < Base

--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -136,13 +136,13 @@ module Xeroizer
         end
                 
       protected
-      
+
         # Attempt to create a new record.
         def create
           request = to_xml
           log "[CREATE SENT] (#{__FILE__}:#{__LINE__}) #{request}"
           
-          response = parent.http_post(request)
+          response = parent.send(parent.create_method, request)
           log "[CREATE RECEIVED] (#{__FILE__}:#{__LINE__}) #{response}"
           
           parse_save_response(response)

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -150,7 +150,7 @@ module Xeroizer
           if @objects[model_class]
             objects = @objects[model_class].values.compact
             return false unless objects.all?(&:valid?)
-            actions = objects.group_by {|o| o.new_record? ? :http_put : :http_post }
+            actions = objects.group_by {|o| o.new_record? ? :http_put : create_method }
             actions.each_pair do |http_method, records|
               records.each_slice(chunk_size) do |some_records|
                 request = to_bulk_xml(some_records)
@@ -179,6 +179,10 @@ module Xeroizer
               parse_records(response, elements)
             end
           end
+        end
+
+        def create_method
+          :http_post
         end
 
       protected


### PR DESCRIPTION
The Accounts endpoint (and possibly others; haven't checked thoroughly yet) doesn't support the POST action yet. Here's a patch to force `create` and `batch_save` to use PUT instead, in that case.
