### PR TITLE
Added URL field to BankTransactions.

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -29,6 +29,7 @@ module Xeroizer
 
       datetime_utc  :updated_date_utc, :api_name => "UpdatedDateUTC"
       date          :fully_paid_on_date
+      string        :url
       string        :reference
       string        :bank_transaction_id, :api_name => "BankTransactionID"
       boolean       :is_reconciled


### PR DESCRIPTION
The field is defined in http://developer.xero.com/documentation/api/banktransactions/, but seems to be missing from the BankTransactions model. Easy fix.
