### PR TITLE
Send the default headers in OAuth as well

### DIFF
--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -51,9 +51,9 @@ module Xeroizer
         @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
-        @client   = OAuth.new(consumer_key, consumer_secret, options)
-        @logger = options[:logger] || false
         @default_headers = options[:default_headers] || {}
+        @client   = OAuth.new(consumer_key, consumer_secret, options.merge({default_headers: default_headers}))
+        @logger = options[:logger] || false
       end
 
   end

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -84,13 +84,13 @@ module Xeroizer
     #
     # @option params [String] :oauth_callback URL to redirect user to when they have authenticated your application with Xero. If not specified, the user will be shown an authorisation code on the screen that they need to get into your application.
     def request_token(params = {})
-      consumer.get_request_token(params)
+      consumer.get_request_token(params, {}, @consumer_options[:default_headers])
     end
     
     # Create an AccessToken from a PUBLIC/PARTNER authorisation.
     def authorize_from_request(rtoken, rsecret, params = {})
       request_token = ::OAuth::RequestToken.new(consumer, rtoken, rsecret)
-      access_token = request_token.get_access_token(params)
+      access_token = request_token.get_access_token(params, {}, @consumer_options[:default_headers])
       update_attributes_from_token(access_token)
     end
     
@@ -116,7 +116,7 @@ module Xeroizer
       access_token = old_token.get_access_token({
         :oauth_session_handle => (session_handle || @session_handle), 
         :token => old_token
-      })
+      }, {}, @consumer_options[:default_headers])
       update_attributes_from_token(access_token)
     end
 


### PR DESCRIPTION
This makes it easier for Xero support staffs to look at issues with OAuth
