### PR TITLE
Add new timezone field to organisation record

### DIFF
--- a/lib/xeroizer/models/organisation.rb
+++ b/lib/xeroizer/models/organisation.rb
@@ -27,6 +27,7 @@ module Xeroizer
       date      :end_of_year_lock_date
       string    :tax_number
       string    :registration_number
+      string    :timezone
       datetime  :created_date_utc, :api_name => 'CreatedDateUTC'
 
       has_many :addresses


### PR DESCRIPTION
Xero added a timezone field to the organisation object, recently.
