### PR TITLE
Add primary key to TaxRate to fix saving

### DIFF
--- a/lib/xeroizer/models/tax_rate.rb
+++ b/lib/xeroizer/models/tax_rate.rb
@@ -9,6 +9,8 @@ module Xeroizer
     
     class TaxRate < Base
       
+      set_primary_key :name
+      
       string  :name
       string  :tax_type
       string  :status


### PR DESCRIPTION
We were having trouble saving `TaxRate` objects because the primary key was missing. This worked like a charm in our monkey patch.
