### PR TITLE
Forbid payment dates in string format.

### DIFF
--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -107,6 +107,8 @@ module Xeroizer
                 real_value = case value
                   when Date         then value.strftime("%Y-%m-%d")
                   when Time         then value.utc.strftime("%Y-%m-%d")
+                  when NilClass     then nil
+                  else raise ArgumentError.new("Expected Date or Time object for the #{field[:api_name]} field")
                 end
                 b.tag!(field[:api_name], real_value)
                 


### PR DESCRIPTION
Presently, the Payment API is failing for me because the date ends up as an empty string in the XML (`<Date></Date>`). This patch fixes that; it's expecting date-like objects to be a Date or a Time, but really they're strings.
