### PR TITLE
add include_archived params for contacts

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -16,7 +16,8 @@ module Xeroizer
           # Parse parameters for GET requests.
           def parse_params(options)
             params = {}
-            params[:ModifiedAfter]  = options[:modified_since] if options[:modified_since]          
+            params[:ModifiedAfter]  = options[:modified_since] if options[:modified_since]
+            params[:includeArchived]  = options[:include_archived] if options[:include_archived]
             params[:order]        = options[:order] if options[:order]
 
             if options[:where]


### PR DESCRIPTION
added Optional parameter for GET Contacts

e.g. includeArchived=true – Contacts with a status of ARCHIVED will be included in the response
