### PR TITLE
Add datetime_utc type to http_proxy

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -108,6 +108,7 @@ module Xeroizer
               when :decimal     then [field[:api_name], expression, value.to_s]
               when :date        then [field[:api_name], expression, "DateTime.Parse(\"#{value.strftime("%Y-%m-%d")}\")"]
               when :datetime    then [field[:api_name], expression, "DateTime.Parse(\"#{value.utc.strftime("%Y-%m-%dT%H:%M:%S")}\")"]
+              when :datetime_utc then [field[:api_name], expression, "DateTime.Parse(\"#{value.utc.strftime("%Y-%m-%dT%H:%M:%S")}\")"]
               when :belongs_to  then
               when :has_many    then
             end


### PR DESCRIPTION
This allows fields of type datetime_utc to be used in where clauses.
The datetime_utc type was added in commit
cdae18e1694e3ce6aa9d333f3443f6d4591ad283 but was never added to
base_model_http_proxy, so you get empty where conditions when you
try to filter on fields of that type. This commit fixes that.
