### PR TITLE
Fixes creation of TaxRates

### DIFF
--- a/lib/xeroizer/models/tax_rate.rb
+++ b/lib/xeroizer/models/tax_rate.rb
@@ -5,9 +5,17 @@ module Xeroizer
             
       set_permissions :read
       
+      # TaxRates can be created using either POST or PUT.
+      # POST will also silently update the tax, which can
+      # be unexpected.  PUT is only for create.
+      def create_method
+        :http_put
+      end
     end
     
     class TaxRate < Base
+      set_primary_key :tax_type
+      set_possible_primary_keys :tax_type, :name
       
       string  :name
       string  :tax_type

--- a/test/unit/models/tax_rate_test.rb
+++ b/test/unit/models/tax_rate_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+require 'mocha/test_unit'
+
+class TaxRateTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
+  end
+
+  should "have a primary key value of :tax_type" do
+    assert_equal :tax_type, Xeroizer::Record::TaxRate.primary_key_name
+  end
+
+  should "build and save a tax rate with components via PUT" do
+    @client.expects(:http_put).with { |client, url, body, extra_params|
+      url == "https://api.xero.com/api.xro/2.0/TaxRates" &&
+        body == expected_tax_rate_create_body
+    }.returns(tax_rate_create_successful_response)
+
+    tax_rate = @client.TaxRate.build(name: 'Test Tax Rate')
+    tax_rate.add_tax_component(name: 'Tax Component', rate: '10.0')
+    tax_rate.save
+
+    assert_equal "Test Tax Rate", tax_rate.name
+    assert_equal "ACTIVE", tax_rate.status
+    assert tax_rate.tax_type.present?
+    assert_equal 1, tax_rate.tax_components.size
+
+    tax_component = tax_rate.tax_components.first
+    assert_equal "Tax Component", tax_component.name
+    assert_equal "10.0", tax_component.rate.to_s
+  end
+
+  def expected_tax_rate_create_body
+    <<-EOS
+<TaxRate>
+  <Name>Test Tax Rate</Name>
+  <TaxComponents>
+    <TaxComponent>
+      <Name>Tax Component</Name>
+      <Rate>10.0</Rate>
+    </TaxComponent>
+  </TaxComponents>
+</TaxRate>
+    EOS
+  end
+
+  def tax_rate_create_successful_response
+    <<-EOS
+<Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Id>d1ec84aa-189f-4e08-b78f-ad62cf4935f4</Id>
+  <Status>OK</Status>
+  <ProviderName>Xero API Previewer</ProviderName>
+  <DateTimeUTC>2014-07-02T19:26:53.3217153Z</DateTimeUTC>
+  <TaxRates>
+    <TaxRate>
+      <Name>Test Tax Rate</Name>
+      <TaxType>TAX018</TaxType>
+      <CanApplyToAssets>true</CanApplyToAssets>
+      <CanApplyToEquity>true</CanApplyToEquity>
+      <CanApplyToExpenses>true</CanApplyToExpenses>
+      <CanApplyToLiabilities>true</CanApplyToLiabilities>
+      <CanApplyToRevenue>true</CanApplyToRevenue>
+      <DisplayTaxRate>10.0000</DisplayTaxRate>
+      <EffectiveRate>10.0000</EffectiveRate>
+      <Status>ACTIVE</Status>
+      <TaxComponents>
+        <TaxComponent>
+          <Name>Tax Component</Name>
+          <Rate>10.0000</Rate>
+          <IsCompound>false</IsCompound>
+        </TaxComponent>
+      </TaxComponents>
+    </TaxRate>
+  </TaxRates>
+</Response>
+    EOS
+  end
+
+end


### PR DESCRIPTION
Before, there was no primary key defined for TaxRates, so attempting to create one resulted in the following exception:

```
TypeError: nil is not a symbol
xeroizer/lib/xeroizer/record/base.rb:52:in `[]'
xeroizer/lib/xeroizer/record/model_definition_helper.rb:88:in `id'
xeroizer/lib/xeroizer/record/base.rb:78:in `new_record?'
xeroizer/lib/xeroizer/record/base.rb:101:in `save'
```

This stemmed from being unable to query whether the TaxRate being created was truly a `new_record?` or not.

This commit fixes that by specifying a primary key, and also ensuring that `PUT` is used to create TaxRates.

We're using this at my organization to successfully create and sync tax rates.
