### PR TITLE
updated gemspec for further oauth versions

### DIFF
--- a/xeroizer.gemspec
+++ b/xeroizer.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "redcarpet"
   s.add_development_dependency "yard"
   s.add_dependency "builder", ">= 2.1.2"
-  s.add_dependency "oauth", "= 0.4.5"
+  s.add_dependency "oauth", ">= 0.4.5"
   s.add_dependency "activesupport"
   s.add_dependency "nokogiri"
   s.add_dependency "tzinfo"


### PR DESCRIPTION
This way Xeroizer may be used with more recent oauth versions !
