### PR TITLE
Fix most unit tests

### DIFF
--- a/lib/xeroizer/models/tax_rate.rb
+++ b/lib/xeroizer/models/tax_rate.rb
@@ -14,11 +14,9 @@ module Xeroizer
     end
     
     class TaxRate < Base
-      set_primary_key :tax_type
-      set_possible_primary_keys :tax_type, :name
-      
       set_primary_key :name
-      
+      set_possible_primary_keys :tax_type, :name
+
       string  :name
       string  :tax_type
       string  :status

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -27,8 +27,9 @@ module Xeroizer
     class TokenExpired < StandardError; end
     class TokenInvalid < StandardError; end
     class RateLimitExceeded < StandardError; end
+    class ConsumerKeyUnknown < StandardError; end
     class UnknownError < StandardError; end
-        
+
     unless defined? XERO_CONSUMER_OPTIONS
       XERO_CONSUMER_OPTIONS = {
         :site               => "https://api.xero.com",

--- a/test/unit/models/bank_transaction_validation_test.rb
+++ b/test/unit/models/bank_transaction_validation_test.rb
@@ -8,7 +8,7 @@ class BankTransactionValidationTest < Test::Unit::TestCase
     
     assert false == instance.valid?, "Expected invalid because of invalid type"
     
-    expected_error = "Invalid type. Expected either SPEND or RECEIVE."
+    expected_error = "Invalid type. Expected either SPEND, RECEIVE, RECEIVE-PREPAYMENT or RECEIVE-OVERPAYMENT."
 
     assert_equal expected_error, instance.errors_for(:type).first, "Expected an error about type"
 

--- a/test/unit/models/tax_rate_test.rb
+++ b/test/unit/models/tax_rate_test.rb
@@ -8,12 +8,12 @@ class TaxRateTest < Test::Unit::TestCase
     @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
   end
 
-  should "have a primary key value of :tax_type" do
-    assert_equal :tax_type, Xeroizer::Record::TaxRate.primary_key_name
+  should "have a primary key value of :name" do
+    assert_equal :name, Xeroizer::Record::TaxRate.primary_key_name
   end
 
   should "build and save a tax rate with components via PUT" do
-    @client.expects(:http_put).with { |client, url, body, extra_params|
+    @client.expects(:http_post).with { |client, url, body, extra_params|
       url == "https://api.xero.com/api.xro/2.0/TaxRates" &&
         body == expected_tax_rate_create_body
     }.returns(tax_rate_create_successful_response)

--- a/test/unit/oauth_test.rb
+++ b/test/unit/oauth_test.rb
@@ -75,7 +75,7 @@ class OAuthTest < Test::Unit::TestCase
     end
     
     should "handle ApiExceptions" do
-      Xeroizer::OAuth.any_instance.stubs(:post).returns(stub(:plain_body => get_file_as_string("api_exception.xml"),
+      Xeroizer::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => get_file_as_string("api_exception.xml"),
           :code => "400"))
       
       assert_raises Xeroizer::ApiException do
@@ -85,7 +85,7 @@ class OAuthTest < Test::Unit::TestCase
     end
     
     should "handle random root elements" do
-      Xeroizer::OAuth.any_instance.stubs(:post).returns(stub(:plain_body => "<RandomRootElement></RandomRootElement>",
+      Xeroizer::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => "<RandomRootElement></RandomRootElement>",
           :code => "200"))
       
       assert_raises Xeroizer::UnparseableResponse do

--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -33,7 +33,7 @@ class RecordBaseTest < Test::Unit::TestCase
     end
     
     should "new_record? should be false after successfully creating a record" do 
-      Xeroizer::OAuth.any_instance.stubs(:post).returns(stub(:plain_body => get_record_xml(:contact), :code => '200'))
+      Xeroizer::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => get_record_xml(:contact), :code => '200'))
       assert_equal(true, @contact.new_record?)
       assert_nil(@contact.contact_id)
       assert_equal(true, @contact.save, "Error saving contact: #{@contact.errors.inspect}")

--- a/test/unit/record/record_association_test.rb
+++ b/test/unit/record/record_association_test.rb
@@ -6,7 +6,7 @@ class RecordAssociationTest < Test::Unit::TestCase
   def setup
     @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
     mock_api('Invoices')
-    @client.stubs(:http_post).returns(get_record_xml(:invoice, "762aa45d-4632-45b5-8087-b4f47690665e"))
+    @client.stubs(:http_put).returns(get_record_xml(:invoice, "762aa45d-4632-45b5-8087-b4f47690665e"))
   end
   
   context "belongs_to association" do


### PR DESCRIPTION
A number of unit tests were broken, this fixes all but the "about logging" tests in test/unit/record/base_test.rb, which are a tangled mess.
- Some puts and posts changed, reflect these in tests
- Add additional ConsumerKeyUnknown error from oauth
- Remove extraneous primary key from TaxRate and fix test
