### PR TITLE
Allow to pass certificates as a string parameter

### DIFF
--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -12,12 +12,12 @@ module Xeroizer
       # 
       # @param [String] consumer_key consumer key/token from application developer (found at http://api.xero.com for your application).
       # @param [String] consumer_secret consumer secret from application developer (found at http://api.xero.com for your application).
-      # @param [String] private_key application's private key for message signing (uploaded to http://api.xero.com)
+      # @param [String] path_to_private_key application's private key for message signing (uploaded to http://api.xero.com)
       # @param [String] ssl_client_cert client-side SSL certificate file to use for requests
       # @param [String] ssl_client_key client-side SSL private key to use for requests
       # @param [Hash] options other options to pass to the GenericApplication constructor
       # @return [PartnerApplication] instance of PrivateApplication
-      def initialize(consumer_key, consumer_secret, private_key, ssl_client_cert, ssl_client_key, options = {})
+      def initialize(consumer_key, consumer_secret, path_to_private_key, ssl_client_cert, ssl_client_key, options = {})
         default_options = {
           :xero_url         => 'https://api-partner.network.xero.com/api.xro/2.0',
           :site             => 'https://api-partner.network.xero.com',
@@ -25,7 +25,7 @@ module Xeroizer
           :signature_method => 'RSA-SHA1'
         }
         options = default_options.merge(options).merge(
-          :private_key      => read_certificate(private_key),
+          :private_key_file => path_to_private_key,
           :ssl_client_cert  => OpenSSL::X509::Certificate.new(read_certificate(ssl_client_cert)),
           :ssl_client_key   => OpenSSL::PKey::RSA.new(read_certificate(ssl_client_key))
         )

--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -12,12 +12,12 @@ module Xeroizer
       # 
       # @param [String] consumer_key consumer key/token from application developer (found at http://api.xero.com for your application).
       # @param [String] consumer_secret consumer secret from application developer (found at http://api.xero.com for your application).
-      # @param [String] path_to_private_key application's private key for message signing (uploaded to http://api.xero.com)
-      # @param [String] path_to_ssl_client_cert client-side SSL certificate file to use for requests
-      # @param [String] path_to_ssl_client_key client-side SSL private key to use for requests
+      # @param [String] private_key application's private key for message signing (uploaded to http://api.xero.com)
+      # @param [String] ssl_client_cert client-side SSL certificate file to use for requests
+      # @param [String] ssl_client_key client-side SSL private key to use for requests
       # @param [Hash] options other options to pass to the GenericApplication constructor
       # @return [PartnerApplication] instance of PrivateApplication
-      def initialize(consumer_key, consumer_secret, path_to_private_key, path_to_ssl_client_cert, path_to_ssl_client_key, options = {})
+      def initialize(consumer_key, consumer_secret, private_key, ssl_client_cert, ssl_client_key, options = {})
         default_options = {
           :xero_url         => 'https://api-partner.network.xero.com/api.xro/2.0',
           :site             => 'https://api-partner.network.xero.com',
@@ -25,9 +25,9 @@ module Xeroizer
           :signature_method => 'RSA-SHA1'
         }
         options = default_options.merge(options).merge(
-          :private_key_file => path_to_private_key,
-          :ssl_client_cert  => OpenSSL::X509::Certificate.new(File.read(path_to_ssl_client_cert)),
-          :ssl_client_key   => OpenSSL::PKey::RSA.new(File.read(path_to_ssl_client_key))
+          :private_key      => read_certificate(private_key),
+          :ssl_client_cert  => OpenSSL::X509::Certificate.new(read_certificate(ssl_client_cert)),
+          :ssl_client_key   => OpenSSL::PKey::RSA.new(read_certificate(ssl_client_key))
         )
         super(consumer_key, consumer_secret, options)
         
@@ -42,5 +42,14 @@ module Xeroizer
         end
       end
     
+    private
+
+      def read_certificate(cert)
+        if cert[-4..-1] == '.pem'
+          File.read(cert)
+        else
+          cert
+        end
+      end
   end
 end


### PR DESCRIPTION
We deploy to heroku which runs ephemeral filesystem that do not allow particular files uploaded, also committing certificates into repository seems like not quite good idea. Everyones recommends [Config Vars](https://devcenter.heroku.com/articles/config-vars) aka environment variables.

I also found that you can easily replace `private_key_file` with string by passing `consumer_secret` thru the options hash:

    Xeroizer::PartnerApplication.new(api_key, secret, nil, ENV['XERO_SSL_CERT'], ENV['XERO_SSL_KEY'], {
      consumer_secret: ENV['XERO_PRIVATE_KEY']
    })
