### PR TITLE
Use invoice line items returned with paged invoice results

### DIFF
--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -100,12 +100,7 @@ module Xeroizer
             when :put   then    client.put(uri.request_uri, raw_body, headers)
           end
 
-          if self.logger
-            logger.info("XeroGateway Response (#{response.code})")
-            unless response.code.to_i == 200
-              logger.info("#{uri.request_uri}\n== Response Body\n\n#{response.plain_body}\n== End Response Body")
-            end
-          end
+          log_response(response, uri)
 
           case response.code.to_i
             when 200
@@ -133,7 +128,16 @@ module Xeroizer
         end
       end
 
-      def handle_oauth_error!(response)
+    def log_response(response, uri)
+      if self.logger
+        logger.info("XeroGateway Response (#{response.code})")
+        logger.add(response.code.to_i == 200 ? Logger::DEBUG : Logger::INFO) {
+          "#{uri.request_uri}\n== Response Body\n\n#{response.plain_body}\n== End Response Body"
+        }
+      end
+    end
+
+    def handle_oauth_error!(response)
         error_details = CGI.parse(response.plain_body)
         description   = error_details["oauth_problem_advice"].first
         problem = error_details["oauth_problem"].first

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -78,7 +78,7 @@ module Xeroizer
       boolean      :has_attachments
 
       belongs_to   :contact
-      has_many     :line_items
+      has_many     :line_items, :complete_on_page => true
       has_many     :payments
       has_many     :credit_notes
 

--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -17,6 +17,7 @@ module Xeroizer
       attr_reader :model
       attr_accessor :errors
       attr_accessor :complete_record_downloaded
+      attr_accessor :paged_record_downloaded
 
       include ModelDefinitionHelper
       include RecordAssociationHelper
@@ -87,6 +88,11 @@ module Xeroizer
           else
             true
           end
+        end
+
+
+        def paged_record_downloaded?
+          !!paged_record_downloaded
         end
 
         # Downloads the complete record if we only have a summary of the record.

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -176,7 +176,7 @@ module Xeroizer
           Response.parse(response_xml, options) do | response, elements, response_model_name |
             if model_name == response_model_name
               @response = response
-              parse_records(response, elements)
+              parse_records(response, elements, paged_records_requested?(options))
             end
           end
         end
@@ -187,8 +187,14 @@ module Xeroizer
 
       protected
 
-        # Parse the records part of the XML response and builds model instances as necessary.
-        def parse_records(response, elements)
+
+        def paged_records_requested?(options)
+          options.has_key?(:page) and options[:page].to_i >= 0
+        end
+
+
+      # Parse the records part of the XML response and builds model instances as necessary.
+        def parse_records(response, elements, paged_results)
           elements.each do | element |
             new_record = model_class.build_from_node(element, self)
             if element.attribute('status').try(:value) == 'ERROR'
@@ -197,6 +203,7 @@ module Xeroizer
                 new_record.errors << err.text.gsub(/^\s+/, '').gsub(/\s+$/, '')
               end
             end
+            new_record.paged_record_downloaded = paged_results
             response.response_items << new_record
           end
         end

--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -127,7 +127,7 @@ module Xeroizer
           # the complete version of the record before accessing the association.
           if list_contains_summary_only?
             define_method internal_field_name do
-              download_complete_record! unless new_record? || options[:list_complete] || complete_record_downloaded?
+              download_complete_record! unless new_record? || options[:list_complete] || options[:complete_on_page] && paged_record_downloaded? || complete_record_downloaded?
               self.attributes[field_name] || ((association_type == :has_many) ? [] : nil)
             end
           end

--- a/test/unit/models/invoice_test.rb
+++ b/test/unit/models/invoice_test.rb
@@ -83,7 +83,27 @@ class InvoiceTest < Test::Unit::TestCase
     end
 
   end
-  
+
+  context "paging" do
+
+    should "have line items without downloading full invoice when paging" do
+
+      invoices = @client.Invoice.all(page: 1)
+
+      invoices.each do |invoice|
+        # This would kick off a full download without page param.
+        invoice.line_items.size
+        assert_equal(true, invoice.paged_record_downloaded?)
+
+        # This indicates that there wasn't a separate download of the individual invoice.
+        assert_equal(false, invoice.complete_record_downloaded?)
+      end
+
+
+    end
+
+  end
+
   context "contact shortcuts" do
     
     should "have valid #contact_name and #contact_id without downloading full invoice" do


### PR DESCRIPTION
* Add option for associations downloaded with paged results. Use
the :complete_with_page flag on association.
* Also add DEBUG-level logging of server xml responses

(This is a resubmission, I messed up the previous branch with a forced update)