### PR TITLE
add GET ContactGroups

### DIFF
--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -15,6 +15,7 @@ module Xeroizer
     record :Attachment
     record :BrandingTheme
     record :Contact
+    record :ContactGroup
     record :CreditNote
     record :Currency
     record :Employee

--- a/lib/xeroizer/models/contact_group.rb
+++ b/lib/xeroizer/models/contact_group.rb
@@ -1,16 +1,19 @@
 module Xeroizer
   module Record
-    
-    class ContactGroupModel < BaseModel      
+
+    class ContactGroupModel < BaseModel
+      set_permissions :read
     end
-    
+
     class ContactGroup < Base
-      
+
       guid :contact_group_id
       string :name
       string :status
-      
+
+      has_many :contacts, :list_complete => true
+
     end
-    
+
   end
 end


### PR DESCRIPTION
First contribution - sorry if I've not followed your preferred methodology.

This is a simple PR to add support for reading the `ContractGroup` model.

As per the Xero docs it will output all contacts on a GET for a specific group: http://developer.xero.com/documentation/api/contactgroups/#title9

e.g:

```ruby
@client.ContactGroup.all
# => [#<Xeroizer::Record::ContactGroup :contact_group_id: "97bbd0e6-ab4d-4117-9304-d90dd4779199", :name: "VIP Customers", :status: "ACTIVE">,
 #<Xeroizer::Record::ContactGroup :contact_group_id: "d0c68f1a-e5dd-4a45-aa02-27d8fdbfd562", :name: "Preferred Suppliers", :status: "ACTIVE">]

@client.ContactGroup.find('97bbd0e6-ab4d-4117-9304-d90dd4779199')
# => #<Xeroizer::Record::ContactGroup :contact_group_id: "97bbd0e6-ab4d-4117-9304-d90dd4779199", :name: "Adam's Contacts", :status: "ACTIVE", :contacts: [#<Xeroizer::Record::Contact :contact_id: "9ce626d2-14ea-463c-9fff-6785ab5f9bfb", :name: "Boom FM">, #<Xeroizer::Record::Contact :contact_id: "b9d4332a-26a3-4577-8db2-6e830d4b07cd", :name: "Berry Brew">, #<Xeroizer::Record::Contact :contact_id: "2dc0ef7c-582f-4542-963b-dbdc069e4819", :name: "Bayside Wholesale">]>
```

(Sorry about the whitespace changes)
