### PR TITLE
Get unit tests passing

### DIFF
--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -56,11 +56,13 @@ class RecordBaseTest < Test::Unit::TestCase
 
   context "about logging" do
     setup do
-      @example_class = Class.new(Xeroizer::Record::Base) do
+      class ExampleRecordClass < Xeroizer::Record::Base
         def valid?; true; end
         def to_xml(b = nil); "<FakeRequest />" end
         string :id
       end
+      class Xeroizer::Record::ExampleRecordClassModel < Xeroizer::Record::BaseModel ; end
+      @example_class = ExampleRecordClass
     end
 
     must "log the request and response xml when saving a new record" do
@@ -69,7 +71,10 @@ class RecordBaseTest < Test::Unit::TestCase
 
       a_fake_parent = mock "Mock parent",
         :http_put => "<FakeResponse />",
-        :parse_response => stub("Stub response", :response_items => [])
+        :parse_response => stub("Stub response", :response_items => []),
+        :mark_dirty => nil,
+        :create_method => :http_put,
+        :mark_clean => nil
 
       an_example_instance = @example_class.new(a_fake_parent)
 
@@ -83,7 +88,9 @@ class RecordBaseTest < Test::Unit::TestCase
 
       a_fake_parent = mock "Mock parent",
         :http_post => "<FakeResponse />",
-        :parse_response => stub("Stub response", :response_items => [])
+        :parse_response => stub("Stub response", :response_items => []),
+        :mark_dirty => nil,
+        :mark_clean => nil
 
       an_example_instance = @example_class.new(a_fake_parent)
 

--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -7,32 +7,32 @@ class RecordBaseTest < Test::Unit::TestCase
     @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
     @contact = @client.Contact.build(:name => 'Test Contact Name ABC')
   end
-  
+
   context "base record" do
-    
+
     should "create new model instance from #new_model_class" do
       model_class = @contact.new_model_class("Invoice")
       assert_kind_of(Xeroizer::Record::InvoiceModel, model_class)
       assert_equal(@contact.parent.application, model_class.application)
       assert_equal('Invoice', model_class.model_name)
     end
-    
+
     should "new_record? should be new on create" do
       assert_equal(true, @contact.new_record?)
     end
-  
+
   end
-  
+
   context "new_record? states" do
-  
+
     should "new_record? should be false when loading data" do
       Xeroizer::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_record_xml(:contact), :code => '200'))
       contact = @client.Contact.find('TESTID')
       assert_kind_of(Xeroizer::Record::Contact, contact)
       assert_equal(false, contact.new_record?)
     end
-    
-    should "new_record? should be false after successfully creating a record" do 
+
+    should "new_record? should be false after successfully creating a record" do
       Xeroizer::OAuth.any_instance.stubs(:put).returns(stub(:plain_body => get_record_xml(:contact), :code => '200'))
       assert_equal(true, @contact.new_record?)
       assert_nil(@contact.contact_id)
@@ -40,20 +40,20 @@ class RecordBaseTest < Test::Unit::TestCase
       assert_equal(false, @contact.new_record?)
       assert(@contact.contact_id =~ GUID_REGEX, "@contact.contact_id is not a GUID, it is '#{@contact.contact_id}'")
     end
-    
+
     should "new_record? should be false if we have specified a primary key" do
       contact = @client.Contact.build(:contact_id => 'ABC')
       assert_equal(false, contact.new_record?)
-      
+
       contact = @client.Contact.build(:contact_number => 'CDE')
       assert_equal(true, contact.new_record?)
-      
+
       contact = @client.Contact.build(:name => 'TEST NAME')
       assert_equal(true, contact.new_record?)
     end
-    
+
   end
-  
+
   context "about logging" do
     setup do
       @example_class = Class.new(Xeroizer::Record::Base) do


### PR DESCRIPTION
Fixed some errors popping up in the unit tests for `Record::Base`. Since the implementation manipulates the class name and uses `const_get` to get the accompanying model class, the tests that used an anonymous class were breaking. Also made a couple of test mocks quack like `BaseModel` instances. The unit tests should be green now.

Another fix for the same issues would be to use a dependency injection rather than the class name manipulation. That would be cleaner to test, but it would change the initialization interface, so I thought I'd submit this way first. We could also use actual classes instead of anonymous stub definitions the way some of the other unit tests do, but this doesn't test the base class itself as conclusively. For the purposes of unit testing an abstract class like this, I like the test-defined child class pattern.