### PR TITLE
Fix bank transaction status validation

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -13,7 +13,7 @@ module Xeroizer
     class BankTransaction < Base
 
       BANK_TRANSACTION_STATUS = {
-        'ACTIVE'  =>          'Active bank transactions',
+        'AUTHORISED'  =>          'Active bank transactions',
         'DELETED' =>          'Deleted bank transactions',
       } unless defined?(BANK_TRANSACTION_STATUS)
       BANK_TRANSACTION_STATUSES = BANK_TRANSACTION_STATUS.keys.sort
@@ -52,7 +52,7 @@ module Xeroizer
       validates_inclusion_of :type,
         :in => %w{SPEND RECEIVE RECEIVE-PREPAYMENT RECEIVE-OVERPAYMENT}, :allow_blanks => false,
         :message => "Invalid type. Expected either SPEND, RECEIVE, RECEIVE-PREPAYMENT or RECEIVE-OVERPAYMENT."
-      validates_inclusion_of :status, :in => BANK_TRANSACTION_STATUSES, :unless => :new_record?
+      validates_inclusion_of :status, :in => BANK_TRANSACTION_STATUSES, :allow_blanks => true
 
       validates_presence_of :contact, :bank_account, :allow_blanks => false
 

--- a/test/unit/models/bank_transaction_validation_test.rb
+++ b/test/unit/models/bank_transaction_validation_test.rb
@@ -25,6 +25,34 @@ class BankTransactionValidationTest < Test::Unit::TestCase
     assert_empty instance.errors_for(:type), "Expected no error about type"
   end
 
+  can "omit the status attribute" do
+    instance = BankTransaction.build({}, nil)
+    instance.valid?
+    assert_empty instance.errors_for(:status), "Expected no error about status"
+  end
+
+  must "supply either AUTHORISED or DELETED as the status" do
+    instance = BankTransaction.build({:status => "xxx"}, nil)
+
+    assert false == instance.valid?, "Expected invalid because of invalid status"
+
+    expected_error = "not one of AUTHORISED, DELETED"
+
+    assert_equal expected_error, instance.errors_for(:status).first, "Expected an error about status"
+
+    instance = BankTransaction.build({:status => "AUTHORISED"}, nil)
+
+    instance.valid?
+
+    assert_empty instance.errors_for(:status), "Expected no error about status"
+
+    instance = BankTransaction.build({:status => "DELETED"}, nil)
+
+    instance.valid?
+
+    assert_empty instance.errors_for(:status), "Expected no error about status"
+  end
+
   must "supply a non-blank contact" do
     instance = BankTransaction.build({}, nil)
 

--- a/test/unit/models/bank_transaction_validation_test.rb
+++ b/test/unit/models/bank_transaction_validation_test.rb
@@ -5,32 +5,32 @@ class BankTransactionValidationTest < Test::Unit::TestCase
 
   must "supply either SPEND or RECEIVE as the type" do
     instance = BankTransaction.build({:type => "xxx"}, nil)
-    
+
     assert false == instance.valid?, "Expected invalid because of invalid type"
-    
+
     expected_error = "Invalid type. Expected either SPEND, RECEIVE, RECEIVE-PREPAYMENT or RECEIVE-OVERPAYMENT."
 
     assert_equal expected_error, instance.errors_for(:type).first, "Expected an error about type"
 
     instance = BankTransaction.build({:type => "SPEND"}, nil)
-    
+
     instance.valid?
-    
+
     assert_empty instance.errors_for(:type), "Expected no error about type"
 
     instance = BankTransaction.build({:type => "RECEIVE"}, nil)
-    
+
     instance.valid?
-    
+
     assert_empty instance.errors_for(:type), "Expected no error about type"
   end
 
   must "supply a non-blank contact" do
     instance = BankTransaction.build({}, nil)
-    
+
     assert false == instance.valid?, "Expected invalid because of missing contact"
 
-    assert_equal "can't be blank", instance.errors_for(:contact).first, 
+    assert_equal "can't be blank", instance.errors_for(:contact).first,
       "Expected an error about blank contact"
   end
 
@@ -64,18 +64,18 @@ class BankTransactionValidationTest < Test::Unit::TestCase
 
     assert false == instance.valid?, "Expected invalid because of missing bank account"
 
-    assert_equal "can't be blank", instance.errors_for(:bank_account).first, 
+    assert_equal "can't be blank", instance.errors_for(:bank_account).first,
       "Expected an error about blank contact"
   end
 
-  must "supply valid line_amount_types value" do 
+  must "supply valid line_amount_types value" do
     instance = BankTransaction.build({
       :line_amount_types => "XXX_ANYTHING_INVALID_XXX"
     }, nil)
 
     assert false == instance.valid?, "Expected invalid because of missing bank account"
 
-    assert_equal "not one of Exclusive, Inclusive, NoTax", instance.errors_for(:line_amount_types).first, 
+    assert_equal "not one of Exclusive, Inclusive, NoTax", instance.errors_for(:line_amount_types).first,
       "Expected an error about blank contact"
   end
 


### PR DESCRIPTION
This resolves Issue #182

Note that this could result in invalidating objects that previously passed validations; in particular, new bank transaction records with a non-empty status other than `AUTHORISED` or `DELETED` will now be invalid (which I believe is true to life according to the [Xero Docs](http://developer.xero.com/documentation/api/types/#BankTransactionStatuses)) where previously they were valid.