### PR TITLE
Add account_number attribute to Contact model

### DIFF
--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -24,6 +24,7 @@ module Xeroizer
       guid          :contact_id
       string        :contact_number
       string        :contact_status
+      string        :account_number
       string        :name
       string        :tax_number
       string        :bank_account_details


### PR DESCRIPTION
First, thanks so much for the effort on Xeroizer! It's been amazingly helpful for some integrations I've worked on.

I was actually setting up an integration today which was being used to create contacts in Xero. I noticed that Xeroizer, as it stands right now, doesn't support the "Account Number" attribute on the Contact model. I've been using that field to store customer numbers for reference in external systems and wanted to be able to add it using the API. 

Seeing that it wasn't there, I went ahead and implemented it. Basic smoke tests proved successful but if you wouldn't mind taking a look at it and letting me know if perhaps I'm overlooking something I'd appreciate it. 

Cheers!

For reference: http://developer.xero.com/documentation/api/contacts/