### PR TITLE
Add TrackingCategoryChild record to generic application

### DIFF
--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -28,6 +28,7 @@ module Xeroizer
     record :Receipt
     record :TaxRate
     record :TrackingCategory
+    record :TrackingCategoryChild
     record :BankTransaction
     record :User
 


### PR DESCRIPTION
When a line item (on a transaction, say) does not have an entry in one of its tracking categories, we must use the `.build` method for `TrackingCategoryChild` to create a new entry, necessitating the `TrackingCategoryChild` model to be available as its own record.