### PR TITLE
Add application option to enable unit price precision to 4 decimal places

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
 Logging
 ---------------
 
-You can add an optional paramater to the Xeroizer Application initialization, to pass a logger object that will need to respond_to :info. For example, in a rails app:
+You can add an optional parameter to the Xeroizer Application initialization, to pass a logger object that will need to respond_to :info. For example, in a rails app:
 
 ```ruby
 XeroLogger = Logger.new('log/xero.log', 'weekly')
@@ -560,6 +560,20 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
                                          YOUR_OAUTH_CONSUMER_SECRET,
                                          :logger => XeroLogger)
 ```
+
+Unit Price Precision
+--------------------
+
+By default, the API accepts unit prices (UnitAmount) to two decimals places. If you require greater precision, you can opt-in to 4 decimal places by setting an optional parameter when initializing an application:
+
+
+```ruby
+client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
+                                         YOUR_OAUTH_CONSUMER_SECRET,
+                                         :unitdp => 4)
+```
+
+This option adds the unitdp=4 query string parameter to all requests for models with line items - invoices, credit notes, bank transactions and receipts.
 
 ### Contributors
 Xeroizer was inspired by the https://github.com/tlconnor/xero_gateway gem created by Tim Connor 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -6,7 +6,7 @@ module Xeroizer
     include Http
     extend Record::ApplicationHelper
 
-    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts, :default_headers
+    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts, :default_headers, :unitdp
 
     extend Forwardable
     def_delegators :client, :access_token
@@ -54,6 +54,7 @@ module Xeroizer
         @default_headers = options[:default_headers] || {}
         @client   = OAuth.new(consumer_key, consumer_secret, options.merge({default_headers: default_headers}))
         @logger = options[:logger] || false
+        @unitdp = options[:unitdp] || 2
       end
 
   end

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -57,6 +57,9 @@ module Xeroizer
 
         headers = self.default_headers.merge({ 'charset' => 'utf-8' })
 
+        # include the unitdp query string parameter 
+        params.merge!(unitdp_param(url))
+        
         if method != :get
           headers['Content-Type'] ||= "application/x-www-form-urlencoded"
         end
@@ -193,6 +196,14 @@ module Xeroizer
 
       def sleep_for(seconds = 1)
         sleep seconds
+      end
+
+      # unitdp query string parameter to be added to request params
+      # when the application option has been set and the model has line items
+      # http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#unitamount
+      def unitdp_param(request_url)
+        models = [/Invoices/, /CreditNotes/, /BankTransactions/, /Receipts/]
+        self.unitdp == 4 && models.any?{ |m| request_url =~ m } ? {:unitdp => 4} : {}
       end
 
   end

--- a/test/unit/generic_application_test.rb
+++ b/test/unit/generic_application_test.rb
@@ -5,13 +5,18 @@ class GenericApplicationTest < Test::Unit::TestCase
 
   def setup
     @headers = {"User-Agent" => "Xeroizer/2.15.5"}
-    @client = Xeroizer::GenericApplication.new(CONSUMER_KEY, CONSUMER_SECRET, :default_headers => @headers)
+    @unitdp = 4
+    @client = Xeroizer::GenericApplication.new(CONSUMER_KEY, CONSUMER_SECRET, :default_headers => @headers, :unitdp => @unitdp)
   end
 
   context "initialization" do
 
     should "pass default headers" do
       assert_equal(@headers, @client.default_headers)
+    end
+
+    should "pass unitdp value" do
+      assert_equal(@unitdp, @client.unitdp)
     end
 
   end


### PR DESCRIPTION
By default, the API accepts unit prices (UnitAmount) to two decimals places. If you require greater precision, you can opt-in to 4 decimal places by setting an optional parameter when initializing an application.

This change adds the unitdp query string parameter to the request params when the application option has been set and the model has line items.

Here's a link to the relevant section in the documentation: http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#unitamount