### PR TITLE
Add contact sales & purchases tracking categories

### DIFF
--- a/lib/xeroizer.rb
+++ b/lib/xeroizer.rb
@@ -57,6 +57,8 @@ require 'xeroizer/models/tracking_category'
 require 'xeroizer/models/tracking_category_child'
 require 'xeroizer/models/user'
 require 'xeroizer/models/journal_line_tracking_category'
+require 'xeroizer/models/contact_sales_tracking_category'
+require 'xeroizer/models/contact_purchases_tracking_category'
 
 require 'xeroizer/report/factory'
 

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -44,6 +44,9 @@ module Xeroizer
       has_many  :contact_groups
       has_many  :contact_persons, :internal_name => :contact_people
 
+      has_many :sales_tracking_categories, :model_name => 'ContactSalesTrackingCategory'
+      has_many :purchases_tracking_categories, :model_name => 'ContactPurchasesTrackingCategory'
+
       validates_presence_of :name
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true
 

--- a/lib/xeroizer/models/contact_purchases_tracking_category.rb
+++ b/lib/xeroizer/models/contact_purchases_tracking_category.rb
@@ -1,0 +1,19 @@
+module Xeroizer
+  module Record
+    
+    class ContactPurchasesTrackingCategoryModel < BaseModel
+    
+      set_xml_root_name 'PurchasesTrackingCategories'
+      set_xml_node_name 'PurchasesTrackingCategory'
+      
+    end
+    
+    class ContactPurchasesTrackingCategory < Base
+      
+      string  :tracking_category_name
+      string  :tracking_option_name
+      
+    end
+    
+  end
+end

--- a/lib/xeroizer/models/contact_sales_tracking_category.rb
+++ b/lib/xeroizer/models/contact_sales_tracking_category.rb
@@ -1,0 +1,19 @@
+module Xeroizer
+  module Record
+    
+    class ContactSalesTrackingCategoryModel < BaseModel
+    
+      set_xml_root_name 'SalesTrackingCategories'
+      set_xml_node_name 'SalesTrackingCategory'
+      
+    end
+    
+    class ContactSalesTrackingCategory < Base
+      
+      string  :tracking_category_name
+      string  :tracking_option_name
+      
+    end
+    
+  end
+end


### PR DESCRIPTION
This change adds the default sales and purchases tracking categories for a contact.

Here's a link to the relevant section in the documentation:
http://developer.xero.com/documentation/api/contacts/