### PR TITLE
Add currency_rate to CreditNote

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -57,6 +57,7 @@ module Xeroizer
       decimal       :total, :calculated => true
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
       string        :currency_code
+      decimal       :currency_rate
       datetime      :fully_paid_on_date
       boolean       :sent_to_contact
       


### PR DESCRIPTION
`currency_rate` is supported in `CreditNote`, but it's still not in the gem yet.