### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: bundle exec rake test:unit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Xeroizer API Library ![Project status](http://stillmaintained.com/waynerobinson/xeroizer.png)
+Xeroizer API Library ![Project status](http://stillmaintained.com/waynerobinson/xeroizer.png) [![Build Status](https://travis-ci.org/waynerobinson/xeroizer.svg)](https://travis-ci.org/waynerobinson/xeroizer)
 ====================
 
 **Homepage**: 		[http://waynerobinson.github.com/xeroizer](http://waynerobinson.github.com/xeroizer)		


### PR DESCRIPTION
Travis CI makes keeping tests passing pretty simple, this PR adds support for it.

To enable it, simply visit http://travis-ci.org/ ; sign up, and enable the waynerobinson/xeroizer repo.

I'd recommend applying #181 just after this one to see it go from failing to passing. 
