### PR TITLE
Add is_reconciled attribute to payments.

### DIFF
--- a/lib/xeroizer/models/payment.rb
+++ b/lib/xeroizer/models/payment.rb
@@ -20,6 +20,7 @@ module Xeroizer
       string        :status
       string        :reference
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
+      boolean       :is_reconciled
 
       belongs_to    :account
       belongs_to    :invoice


### PR DESCRIPTION
An optional parameter for the payment. A boolean indicating whether you would like the payment to be created as reconciled when using PUT, or whether a payment has been reconciled when using GET

Fixes #198

http://developer.xero.com/documentation/api/payments/ 