### PR TITLE
Add an "allocate" method for CreditNotes.

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -128,7 +128,11 @@ module Xeroizer
         end
 
         def save
+          # Calling parse_save_response() on the credit note will wipe out
+          # the allocations, so we have to manually preserve them.
+          allocations_backup = allocations
           super
+          allocations = allocations_backup
           allocate if !allocations.empty?
         end
 

--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -126,8 +126,21 @@ module Xeroizer
         def pdf(filename = nil)
           parent.pdf(id, filename)
         end
-              
+
+        def allocate
+          if self.class.possible_primary_keys && self.class.possible_primary_keys.all? { | possible_key | self[possible_key].nil? }
+            raise RecordKeyMustBeDefined.new(self.class.possible_primary_keys)
+          end
+
+          request = association_to_xml(:allocations)
+          allocations_url = "#{parent.url}/#{CGI.escape(id)}/Allocations"
+
+          log "[ALLOCATION SENT] (#{__FILE__}:#{__LINE__}) \r\n#{request}"
+          response = parent.application.http_put(parent.application.client, allocations_url, request)
+          log "[ALLOCATION RECEIVED] (#{__FILE__}:#{__LINE__}) \r\n#{response}"
+          parse_save_response(response)
+        end
     end
-    
+
   end
 end

--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -131,9 +131,11 @@ module Xeroizer
           # Calling parse_save_response() on the credit note will wipe out
           # the allocations, so we have to manually preserve them.
           allocations_backup = allocations
-          super
-          allocations = allocations_backup
-          allocate if !allocations.empty?
+          if super
+            allocations = allocations_backup
+            allocate if !allocations.empty?
+            true
+          end
         end
 
         def allocate

--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -127,6 +127,11 @@ module Xeroizer
           parent.pdf(id, filename)
         end
 
+        def save
+          super
+          allocate if !allocations.empty?
+        end
+
         def allocate
           if self.class.possible_primary_keys && self.class.possible_primary_keys.all? { | possible_key | self[possible_key].nil? }
             raise RecordKeyMustBeDefined.new(self.class.possible_primary_keys)

--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -126,9 +126,17 @@ module Xeroizer
 
             end
           end
-        
+
+          def association_to_xml(association_name)
+            builder = Builder::XmlMarkup.new(indent: 2)
+            records = send(association_name)
+
+            optional_root_tag(association_name.to_s.camelize, builder) do |b|
+              records.each { |record| record.to_xml(b) }
+            end
+          end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
Allocating credit notes through the API is intensely annoying; instead of just being able to update the credit note with an appropriate `<Allocations>` section, you have to send a separate PUT request to `.../CreditNotes/<id>/Allocations` containing only the `<Allocations>` tag. There doesn't appear to be any way to do them in bulk at present.

This should allow us to do allocations for individual credit notes.