### PR TITLE
Allow overriding the 'list_contains_summary_only' option.

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -63,7 +63,7 @@ module Xeroizer
       
       belongs_to    :contact
       has_many      :line_items
-      has_many      :allocations
+      has_many      :allocations, complete: true
       
       validates_inclusion_of :type, :in => CREDIT_NOTE_TYPES
       validates_inclusion_of :status, :in => CREDIT_NOTE_STATUSES, :allow_blanks => true

--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -122,10 +122,11 @@ module Xeroizer
             end
           end
 
-          # Override reader for this association if this association belongs
-          # to a summary-typed record. This will automatically attempt to download
-          # the complete version of the record before accessing the association.
-          if list_contains_summary_only?
+          # Override reader for this association if this is a summary-typed association.
+          # This will automatically attempt to download the complete version of the
+          # record before accessing the association.
+          if (list_contains_summary_only? && options[:complete] != true) ||
+             (!list_contains_summary_only? && options[:complete] == false)
             define_method internal_field_name do
               download_complete_record! unless new_record? || options[:list_complete] || complete_record_downloaded?
               self.attributes[field_name] || ((association_type == :has_many) ? [] : nil)


### PR DESCRIPTION
The problem here is that the `list_contains_summary_only` property on models isn't actually a model-wide property, but a per-association one. Credit notes, for instance, will show summarized versions of Contacts, but will return the Allocations in full. Then, when you ask for the allocations in the model, it'll download all of the relevant records with `download_complete_record!`, even though Xero already sent the complete Allocation list!

To save many unnecessary round trips to the API, I've added a flag to association definitions to allow overriding the `list_contains_summary_only` behaviour on the level of individual associations. There are probably other associations that could make use of this besides credit note allocations, and I'll make new PRs to add flags to them if and when I notice them.
