### PR TITLE
use journal lines/line items from response when available

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -43,7 +43,7 @@ module Xeroizer
 
       belongs_to :contact, :model_name => 'Contact'
       string :line_amount_types
-      has_many :line_items, :model_name => 'LineItem'
+      has_many :line_items, :model_name => 'LineItem', :complete_on_page => true
       belongs_to :bank_account, :model_name => 'BankAccount'
 
       validates_inclusion_of :line_amount_types,

--- a/lib/xeroizer/models/manual_journal.rb
+++ b/lib/xeroizer/models/manual_journal.rb
@@ -29,7 +29,7 @@ module Xeroizer
       boolean       :show_on_cash_basis_reports
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
       
-      has_many      :journal_lines, :model_name => 'ManualJournalLine'
+      has_many      :journal_lines, :model_name => 'ManualJournalLine', :complete_on_page => true
       
       validates_presence_of :narration
       validates_associated :journal_lines

--- a/test/unit/models/manual_journal_test.rb
+++ b/test/unit/models/manual_journal_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ManualJournalTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
+    mock_api('ManualJournals')
+  end
+
+  context "paging" do
+    should "have journal lines without downloading full manual journal when paging" do
+      manual_journals = @client.ManualJournal.all(page: 1)
+
+      manual_journals.each do |manual_journal|
+        # This would kick off a full download without page param.
+        manual_journal.journal_lines.size
+        assert_equal(true, manual_journal.paged_record_downloaded?)
+
+        # This indicates that there wasn't a separate download of the individual manual journal.
+        assert_equal(false, manual_journal.complete_record_downloaded?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Xero now provides line items for Manual Journal and Bank Transactions for paged requests. This PR adds support to xeroizer, building on #176 by @pinfieldharm

I've added tests for ManualJournal, although skipped them for BankTransaction, as there aren't any mocked responses for it (and I don't have any I'm allowed to make public). BankTransaction and Invoice are basically identical, so this shouldn't be a problem.