### PR TITLE
Do not use value_if_nil for falsy (non-nil) values

### DIFF
--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -67,8 +67,8 @@ module Xeroizer
             :api_name       => options[:api_name] || field_name.to_s.camelize,
             :type           => field_type
           })
-          define_method internal_field_name do 
-            @attributes[field_name] || value_if_nil
+          define_method internal_field_name do
+            @attributes[field_name] == nil ? value_if_nil : @attributes[field_name]
           end
           
           unless options[:skip_writer]

--- a/test/unit/record/model_definition_test.rb
+++ b/test/unit/record/model_definition_test.rb
@@ -159,7 +159,97 @@ class ModelDefinitionsTest < Test::Unit::TestCase
       assert_equal(value, @record[:name])
       assert_equal(value, @record.name)
     end
-    
+
+    should "use declared value_if_nil when value is nil or key is omitted" do
+      unique_truthy_value_if_nil = 'NONSENSE'
+
+      @record.class_eval {
+        define_simple_attribute(:string_field, :string, {}, unique_truthy_value_if_nil)
+      }
+
+      assert_equal(nil, @record.attributes[:string_field])
+      assert_equal(unique_truthy_value_if_nil, @record.string_field)
+      @record.attributes[:string_field] = nil
+      assert_equal(nil, @record.attributes[:string_field])
+      assert_equal(unique_truthy_value_if_nil, @record.string_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:boolean_field, :boolean, {}, unique_truthy_value_if_nil)
+      }
+
+      assert_equal(nil, @record.attributes[:boolean_field])
+      assert_equal(unique_truthy_value_if_nil, @record.boolean_field)
+      @record.attributes[:boolean_field] = nil
+      assert_equal(nil, @record.attributes[:boolean_field])
+      assert_equal(unique_truthy_value_if_nil, @record.boolean_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:integer_field, :integer, {}, unique_truthy_value_if_nil)
+      }
+
+      assert_equal(nil, @record.attributes[:integer_field])
+      assert_equal(unique_truthy_value_if_nil, @record.integer_field)
+      @record.attributes[:integer_field] = nil
+      assert_equal(nil, @record.attributes[:integer_field])
+      assert_equal(unique_truthy_value_if_nil, @record.integer_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:decimal_field, :decimal, {}, unique_truthy_value_if_nil)
+      }
+
+      assert_equal(nil, @record.attributes[:decimal_field])
+      assert_equal(unique_truthy_value_if_nil, @record.decimal_field)
+      @record.attributes[:string_field] = nil
+      assert_equal(nil, @record.attributes[:decimal_field])
+      assert_equal(unique_truthy_value_if_nil, @record.decimal_field)
+
+    end
+
+    should "not use declared value_if_nil when value is falsy/falsey (and not NilClass)" do
+      # The only falsy values in strict ruby are NilClass and FalseClass, but activesupport .present is in gemspec
+
+      unique_truthy_value_if_nil = 'NONSENSE'
+
+      @record.class_eval {
+        define_simple_attribute(:string_field, :string, {}, unique_truthy_value_if_nil)
+      }
+
+      @record.attributes[:string_field] = ""
+      assert_equal("", @record.attributes[:string_field])
+      assert_equal("", @record.string_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:boolean_field, :boolean, {}, unique_truthy_value_if_nil)
+      }
+
+      @record.attributes[:boolean_field] = false
+      assert_equal(false, @record.attributes[:boolean_field])
+      assert_equal(false, @record.boolean_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:integer_field, :integer, {}, unique_truthy_value_if_nil)
+      }
+
+      @record.attributes[:integer_field] = 0
+      assert_equal(0, @record.attributes[:integer_field])
+      assert_equal(0, @record.integer_field)
+
+
+      @record.class_eval {
+        define_simple_attribute(:decimal_field, :decimal, {}, unique_truthy_value_if_nil)
+      }
+
+      @record.attributes[:decimal_field] = 0.0
+      assert_equal(0.0, @record.attributes[:decimal_field])
+      assert_equal(0.0, @record.decimal_field)
+
+
+    end
   end
   
 end


### PR DESCRIPTION
I noticed this (probable) bug for `Xeroizer::Record::Contact.is_supplier()` and `Xeroizer::Record::Contact[:is_supplier]` which return nil instead of false when the value is an instance of FalseClass

Looking at where that code originally came from, I noticed a similar implementation in RecordAssociationHelper.define_association_attribute which has since been updated. Specifically what is now

``` ruby
          if list_contains_summary_only?
            define_method internal_field_name do
              download_complete_record! unless new_record? || options[:list_complete] || options[:complete_on_page] && paged_record_downloaded? || complete_record_downloaded?
              self.attributes[field_name] || ((association_type == :has_many) ? [] : nil)
            end
          end
```

lib/xeroizer/record/record_association_helper.rb:131

Perhaps this line should also compare to `nil` instead of using logical OR but it seems unlikely that something defined as an association might be serialized as 'False' etc and deserialize as an instance of FalseClass, so I left it unchanged.

---

btw there is some weirdness (as shown in unit tests) that for values of nil, `obj.attributes[:attr]` will have the literal value whereas obj.attr and obj[:attr] will have the `value_if_nil` for that field type. Also while writing the tests, I had an error in the test case due to mixing key 'string_field' and key :string_field between the declaration and usage, not sure if it is worth making @attributes a hash with indifferent access.
