### PR TITLE
Add attachment include online option

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,36 @@ invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
 puts "Invoice Contact Name: #{invoice.contact.name}"
 ```
 
+Attachments
+------------
+Files or raw data can be attached to record types
+**attach\_data examples:**
+```ruby
+invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
+invoice.attach_data(“example.txt”, “This is raw data”, “txt”)
+```
+
+```ruby
+attach_data('cd09aa49-134d-40fb-a52b-b63c6a91d712', “example.txt”, “This is raw data”, “txt”)
+```
+
+**attach\_file examples:**
+```ruby
+invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
+invoice.attach_file(“example.png”, “/path/to/image.png”, “image/png”)
+```
+
+```ruby
+attach_file('cd09aa49-134d-40fb-a52b-b63c6a91d712', “example.png”, “/path/to/image.png”, “image/png”)
+```
+
+**include with online invoice**
+To include an attachment with an invoice set optional include_online parameter to true
+```ruby
+invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
+invoice.attach_file(“example.png”, “/path/to/image.png”, “image/png”, true)
+```
+
 Creating/Updating Data
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -397,28 +397,28 @@ Files or raw data can be attached to record types
 **attach\_data examples:**
 ```ruby
 invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
-invoice.attach_data(“example.txt”, “This is raw data”, “txt”)
+invoice.attach_data("example.txt", "This is raw data", "txt")
 ```
 
 ```ruby
-attach_data('cd09aa49-134d-40fb-a52b-b63c6a91d712', “example.txt”, “This is raw data”, “txt”)
+attach_data('cd09aa49-134d-40fb-a52b-b63c6a91d712', "example.txt", "This is raw data", "txt")
 ```
 
 **attach\_file examples:**
 ```ruby
 invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
-invoice.attach_file(“example.png”, “/path/to/image.png”, “image/png”)
+invoice.attach_file("example.png", "/path/to/image.png", "image/png")
 ```
 
 ```ruby
-attach_file('cd09aa49-134d-40fb-a52b-b63c6a91d712', “example.png”, “/path/to/image.png”, “image/png”)
+attach_file('cd09aa49-134d-40fb-a52b-b63c6a91d712', "example.png", "/path/to/image.png", "image/png")
 ```
 
 **include with online invoice**
-To include an attachment with an invoice set optional include_online parameter to true
+To include an attachment with an invoice set include_online parameter to true within the options hash
 ```ruby
 invoice = xero.Invoice.find('cd09aa49-134d-40fb-a52b-b63c6a91d712')
-invoice.attach_file(“example.png”, “/path/to/image.png”, “image/png”, true)
+invoice.attach_file("example.png", "/path/to/image.png", "image/png", { include_online: true })
 ```
 
 Creating/Updating Data

--- a/lib/xeroizer/models/attachment.rb
+++ b/lib/xeroizer/models/attachment.rb
@@ -4,12 +4,12 @@ module Xeroizer
     class AttachmentModel < BaseModel
 
       module Extensions
-        def attach_data(id, filename, data, content_type = "application/octet-stream")
-          application.Attachment.attach_data(url, id, filename, data, content_type)
+        def attach_data(id, filename, data, content_type = "application/octet-stream", include_online = false)
+          application.Attachment.attach_data(url, id, filename, data, content_type, include_online)
         end
 
-        def attach_file(id, filename, path, content_type = "application/octet-stream")
-          application.Attachment.attach_file(url, id, filename, path, content_type)
+        def attach_file(id, filename, path, content_type = "application/octet-stream", include_online = false)
+          application.Attachment.attach_file(url, id, filename, path, content_type, include_online)
         end
 
         def attachments(id)
@@ -19,11 +19,11 @@ module Xeroizer
 
       set_permissions :read
 
-      def attach_data(url, id, filename, data, content_type)
+      def attach_data(url, id, filename, data, content_type, include_online = false)
         response_xml = @application.http_put(@application.client,
                                               "#{url}/#{CGI.escape(id)}/Attachments/#{CGI.escape(filename)}",
                                               data,
-                                              :raw_body => true, :content_type => content_type
+                                              :raw_body => true, :content_type => content_type, "IncludeOnline" => include_online
                                              )
         response = parse_response(response_xml)
         if (response_items = response.response_items) && response_items.size > 0
@@ -33,8 +33,8 @@ module Xeroizer
         end
       end
 
-      def attach_file(url, id, filename, path, content_type)
-        attach_data(url, id, filename, File.read(path), content_type)
+      def attach_file(url, id, filename, path, content_type, include_online = false)
+        attach_data(url, id, filename, File.read(path), content_type, include_online)
       end
 
       def attachments_for(url, id)
@@ -54,12 +54,12 @@ module Xeroizer
     class Attachment < Base
 
       module Extensions
-        def attach_file(filename, path, content_type = "application/octet-stream")
-          parent.attach_file(id, filename, path, content_type)
+        def attach_file(filename, path, content_type = "application/octet-stream", include_online = false)
+          parent.attach_file(id, filename, path, content_type, include_online)
         end
 
-        def attach_data(filename, data, content_type = "application/octet-stream")
-          parent.attach_data(id, filename, data, content_type)
+        def attach_data(filename, data, content_type = "application/octet-stream", include_online = false)
+          parent.attach_data(id, filename, data, content_type, include_online)
         end
 
         def attachments

--- a/lib/xeroizer/models/attachment.rb
+++ b/lib/xeroizer/models/attachment.rb
@@ -4,12 +4,12 @@ module Xeroizer
     class AttachmentModel < BaseModel
 
       module Extensions
-        def attach_data(id, filename, data, content_type = "application/octet-stream", include_online = false)
-          application.Attachment.attach_data(url, id, filename, data, content_type, include_online)
+        def attach_data(id, filename, data, content_type = "application/octet-stream", options = {})
+          application.Attachment.attach_data(url, id, filename, data, content_type, options)
         end
 
-        def attach_file(id, filename, path, content_type = "application/octet-stream", include_online = false)
-          application.Attachment.attach_file(url, id, filename, path, content_type, include_online)
+        def attach_file(id, filename, path, content_type = "application/octet-stream", options = {})
+          application.Attachment.attach_file(url, id, filename, path, content_type, options)
         end
 
         def attachments(id)
@@ -19,11 +19,13 @@ module Xeroizer
 
       set_permissions :read
 
-      def attach_data(url, id, filename, data, content_type, include_online = false)
+      def attach_data(url, id, filename, data, content_type, options = {})
+        options = { include_online: false }.merge(options)
+
         response_xml = @application.http_put(@application.client,
                                               "#{url}/#{CGI.escape(id)}/Attachments/#{CGI.escape(filename)}",
                                               data,
-                                              :raw_body => true, :content_type => content_type, "IncludeOnline" => include_online
+                                              :raw_body => true, :content_type => content_type, "IncludeOnline" => options[:include_online]
                                              )
         response = parse_response(response_xml)
         if (response_items = response.response_items) && response_items.size > 0
@@ -33,8 +35,8 @@ module Xeroizer
         end
       end
 
-      def attach_file(url, id, filename, path, content_type, include_online = false)
-        attach_data(url, id, filename, File.read(path), content_type, include_online)
+      def attach_file(url, id, filename, path, content_type, options = {})
+        attach_data(url, id, filename, File.read(path), content_type, options)
       end
 
       def attachments_for(url, id)
@@ -54,12 +56,12 @@ module Xeroizer
     class Attachment < Base
 
       module Extensions
-        def attach_file(filename, path, content_type = "application/octet-stream", include_online = false)
-          parent.attach_file(id, filename, path, content_type, include_online)
+        def attach_file(filename, path, content_type = "application/octet-stream", options = {})
+          parent.attach_file(id, filename, path, content_type, options)
         end
 
-        def attach_data(filename, data, content_type = "application/octet-stream", include_online = false)
-          parent.attach_data(id, filename, data, content_type, include_online)
+        def attach_data(filename, data, content_type = "application/octet-stream", options = {})
+          parent.attach_data(id, filename, data, content_type, options)
         end
 
         def attachments


### PR DESCRIPTION
Needed to add attachment files directly to invoices. To enable the attachment to be viewed with the online invoice the `IncludeOnline = true` parameter must be passed through with the put/post request.
See attachments documentation for more details: http://developer.xero.com/documentation/api/attachments/

Changes:
- Added optional include_online field to attach_data and attach_file methods in the attachment model.
- Updated README to include examples of adding attachments as  well as including attachments to an online invoice.  