### PR TITLE
LineItem LineItemID Property

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -19,6 +19,7 @@ module Xeroizer
       decimal :tax_amount
       decimal :line_amount, :calculated => true
       decimal :discount_rate
+      string  :line_item_id
       
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
       


### PR DESCRIPTION
Add LineItemId property so that we can programatically match the Line Item's 
we hold against the LineItem's returned from Xero

http://developer.xero.com/documentation/api/invoices/#title2