### PR TITLE
add tracking option id for journal line tracking categories

### DIFF
--- a/lib/xeroizer/models/journal_line_tracking_category.rb
+++ b/lib/xeroizer/models/journal_line_tracking_category.rb
@@ -13,6 +13,7 @@ module Xeroizer
       string  :name
       string  :option
       guid    :tracking_category_id
+      guid    :tracking_option_id
       
     end
     


### PR DESCRIPTION
Adds the tracking_option_id field to Journal Line tracking categories. It is always available, so may as well make it available.