### PR TITLE
Add before & after callbacks around HTTP requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,25 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
                                          :logger => XeroLogger)
 ```
 
+HTTP Callbacks
+--------------------
+
+You can provide "before" and "after" callbacks which will be invoked every
+time Xeroizer makes an HTTP request, which is potentially useful for both
+throttling and logging:
+
+```ruby
+Xeroizer::PublicApplication.new(
+  credentials[:key], credentials[:secret],
+  before_request: ->(request) { puts "Hitting this URL: #{request.url}" },
+  after_request: ->(request, response) { puts "Got this response: #{response.code}" }
+)
+```
+
+The `request` parameter is a custom Struct with `url`, `headers`, `body`,
+and `params` methods. The `response` parameter is a Net::HTTPResponse object.
+
+
 Unit Price Precision
 --------------------
 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -6,7 +6,8 @@ module Xeroizer
     include Http
     extend Record::ApplicationHelper
 
-    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts, :default_headers, :unitdp
+    attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts,
+                :default_headers, :unitdp, :before_request, :after_request
 
     extend Forwardable
     def_delegators :client, :access_token
@@ -58,6 +59,8 @@ module Xeroizer
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
         @default_headers = options[:default_headers] || {}
+        @before_request = options.delete(:before_request)
+        @after_request = options.delete(:after_request)
         @client   = OAuth.new(consumer_key, consumer_secret, options.merge({default_headers: default_headers}))
         @logger = options[:logger] || false
         @unitdp = options[:unitdp] || 2


### PR DESCRIPTION
This adds callbacks around all of Xeroizer's HTTP requests, which turns out to be extremely useful.