### PR TITLE
XeroizerError

### DIFF
--- a/lib/xeroizer/exceptions.rb
+++ b/lib/xeroizer/exceptions.rb
@@ -13,7 +13,10 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 module Xeroizer
-  class ApiException < StandardError
+  
+  class XeroizerError < StandardError; end
+  
+  class ApiException < XeroizerError
     
     attr_reader :type, :message, :xml, :parsed_xml, :request_body
     
@@ -41,7 +44,7 @@ module Xeroizer
     
   end
   
-  class UnparseableResponse < StandardError
+  class UnparseableResponse < XeroizerError
     
     def initialize(root_element_name)
       @root_element_name = root_element_name
@@ -53,7 +56,7 @@ module Xeroizer
       
   end
   
-  class ObjectNotFound < StandardError
+  class ObjectNotFound < XeroizerError
     
     def initialize(api_endpoint)
       @api_endpoint = api_endpoint
@@ -65,11 +68,11 @@ module Xeroizer
     
   end
   
-  class InvoiceNotFoundError < StandardError; end
+  class InvoiceNotFoundError < XeroizerError; end
 
-  class CreditNoteNotFoundError < StandardError; end
+  class CreditNoteNotFoundError < XeroizerError; end
   
-  class MethodNotAllowed < StandardError
+  class MethodNotAllowed < XeroizerError
     
     def initialize(klass, method)
       @klass = klass
@@ -82,7 +85,7 @@ module Xeroizer
     
   end
   
-  class RecordKeyMustBeDefined < StandardError
+  class RecordKeyMustBeDefined < XeroizerError
     
     def initialize(possible_keys)
       @possible_keys = possible_keys
@@ -94,7 +97,7 @@ module Xeroizer
     
   end
 
-  class SettingTotalDirectlyNotSupported < StandardError
+  class SettingTotalDirectlyNotSupported < XeroizerError
     
     def initialize(attribute_name)
       @attribute_name = attribute_name
@@ -106,7 +109,7 @@ module Xeroizer
     
   end
 
-  class InvalidAttributeInWhere < StandardError
+  class InvalidAttributeInWhere < XeroizerError
     
     def initialize(model_name, attribute_name)
       @model_name = model_name
@@ -119,7 +122,7 @@ module Xeroizer
     
   end
   
-  class AssociationTypeMismatch < StandardError
+  class AssociationTypeMismatch < XeroizerError
     
     def initialize(model_class, actual_class)
       @model_class = model_class
@@ -132,7 +135,7 @@ module Xeroizer
     
   end
 
-  class CannotChangeInvoiceStatus < StandardError
+  class CannotChangeInvoiceStatus < XeroizerError
 
     def initialize(invoice, new_status)
       @invoice = invoice


### PR DESCRIPTION
I would propose including a XeroizerError which all Xeroizer Exception Classes inherit from to make catching and processing specially Xeroizer Exceptions easier e.g.

```
    def catch_and_deliver_api_error
      yield 
    rescue Xeroizer::XeroizerError => e
      deliver_api_error_notifications(e)
      raise
    end
```