### PR TITLE
Add extra attributes (balances, payment_terms, batch_payments) to Contact

### DIFF
--- a/lib/xeroizer/models/accounts_payable.rb
+++ b/lib/xeroizer/models/accounts_payable.rb
@@ -1,0 +1,13 @@
+module Xeroizer
+  module Record
+    
+    class AccountsPayableModel < BaseModel
+      set_permissions :read
+    end
+    
+    class AccountsPayable < Base
+      decimal :outstanding
+      decimal :overdue
+    end
+  end
+end

--- a/lib/xeroizer/models/accounts_receivable.rb
+++ b/lib/xeroizer/models/accounts_receivable.rb
@@ -1,0 +1,13 @@
+module Xeroizer
+  module Record
+    
+    class AccountsReceivableModel < BaseModel
+      set_permissions :read
+    end
+    
+    class AccountsReceivable < Base
+      decimal :outstanding
+      decimal :overdue
+    end
+  end
+end

--- a/lib/xeroizer/models/balances.rb
+++ b/lib/xeroizer/models/balances.rb
@@ -1,0 +1,16 @@
+require "xeroizer/models/accounts_receivable"
+require "xeroizer/models/accounts_payable"
+
+module Xeroizer
+  module Record
+    
+    class BalancesModel < BaseModel
+      set_permissions :read
+    end
+    
+    class Balances < Base
+      has_one :accounts_receivable
+      has_one :accounts_payable
+    end
+  end
+end

--- a/lib/xeroizer/models/batch_payments.rb
+++ b/lib/xeroizer/models/batch_payments.rb
@@ -1,0 +1,14 @@
+module Xeroizer
+  module Record
+    
+    class BatchPaymentsModel < BaseModel
+      set_permissions :read
+    end
+    
+    class BatchPayments < Base
+      guid   :bank_account_number
+      string :bank_account_name
+      string :details
+    end
+  end
+end

--- a/lib/xeroizer/models/bills.rb
+++ b/lib/xeroizer/models/bills.rb
@@ -1,0 +1,13 @@
+module Xeroizer
+  module Record
+    
+    class BillsModel < BaseModel
+      set_permissions :read
+    end
+    
+    class Bills < Base
+      string :day
+      string :type
+    end
+  end
+end

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -1,6 +1,7 @@
 require "xeroizer/models/contact_person"
 require "xeroizer/models/balances"
 require "xeroizer/models/batch_payments"
+require "xeroizer/models/payment_terms"
 
 module Xeroizer
   module Record
@@ -54,6 +55,7 @@ module Xeroizer
 
       has_one :balances ,:model_name => 'Balances', :list_complete => true
       has_one :batch_payments ,:model_name => 'BatchPayments', :list_complete => true
+      has_one :payment_terms ,:model_name => 'PaymentTerms', :list_complete => true
 
       validates_presence_of :name
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -1,4 +1,5 @@
 require "xeroizer/models/contact_person"
+require "xeroizer/models/balances"
 
 module Xeroizer
   module Record
@@ -49,6 +50,8 @@ module Xeroizer
 
       has_many :sales_tracking_categories, :model_name => 'ContactSalesTrackingCategory'
       has_many :purchases_tracking_categories, :model_name => 'ContactPurchasesTrackingCategory'
+
+      has_one :balances ,:model_name => 'Balances', :list_complete => true
 
       validates_presence_of :name
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -1,5 +1,6 @@
 require "xeroizer/models/contact_person"
 require "xeroizer/models/balances"
+require "xeroizer/models/batch_payments"
 
 module Xeroizer
   module Record
@@ -52,6 +53,7 @@ module Xeroizer
       has_many :purchases_tracking_categories, :model_name => 'ContactPurchasesTrackingCategory'
 
       has_one :balances ,:model_name => 'Balances', :list_complete => true
+      has_one :batch_payments ,:model_name => 'BatchPayments', :list_complete => true
 
       validates_presence_of :name
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true

--- a/lib/xeroizer/models/payment_terms.rb
+++ b/lib/xeroizer/models/payment_terms.rb
@@ -1,0 +1,16 @@
+require "xeroizer/models/bills"
+require "xeroizer/models/sales"
+
+module Xeroizer
+  module Record
+    
+    class PaymentTermsModel < BaseModel
+      set_permissions :read
+    end
+    
+    class PaymentTerms < Base
+      has_one :bills, :model_name => 'Bills'
+      has_one :sales, :model_name => 'Sales'
+    end
+  end
+end

--- a/lib/xeroizer/models/sales.rb
+++ b/lib/xeroizer/models/sales.rb
@@ -1,0 +1,13 @@
+module Xeroizer
+  module Record
+    
+    class SalesModel < BaseModel
+      set_permissions :read
+    end
+    
+    class Sales < Base
+      string :day
+      string :type
+    end
+  end
+end

--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -29,6 +29,8 @@ module Xeroizer
             self.attributes[field_name] = record
           end
         end
+        
+        alias_method :has_one, :belongs_to
 
         def has_many(field_name, options = {})
           internal_field_name = options[:internal_name] || field_name

--- a/test/stub_responses/contact_with_details.xml
+++ b/test/stub_responses/contact_with_details.xml
@@ -1,5 +1,5 @@
 <Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Id>42d8b00c-2fdd-4a8a-9b84-82cfe78ff34a</Id>
+  <Id>1238b00c-2fdd-4a8a-9b84-82cfe78ff34a</Id>
   <Status>OK</Status>
   <ProviderName>Test Provider Name</ProviderName>
   <DateTimeUTC>2010-12-20T04:13:44.7828584Z</DateTimeUTC>
@@ -48,7 +48,32 @@
       <UpdatedDateUTC>2009-05-14T01:44:26.747</UpdatedDateUTC>
       <IsSupplier>false</IsSupplier>
       <IsCustomer>true</IsCustomer>
-      <DefaultCurrency>NZD</DefaultCurrency>  
+      <DefaultCurrency>NZD</DefaultCurrency>
+      <Balances>
+        <AccountsReceivable>
+          <Outstanding>849.50</Outstanding>
+          <Overdue>910.00</Overdue>
+        </AccountsReceivable>
+        <AccountsPayable>
+          <Outstanding>0.00</Outstanding>
+          <Overdue>0.00</Overdue>
+        </AccountsPayable>
+      </Balances>
+      <BatchPayments>
+        <BankAccountNumber>123456</BankAccountNumber>
+        <BankAccountName>bank account</BankAccountName>
+        <Details>details</Details>
+      </BatchPayments>
+      <PaymentTerms>
+        <Bills>
+          <Day>4</Day>
+          <Type>OFFOLLOWINGMONTH</Type>
+        </Bills>
+        <Sales>
+          <Day>2</Day>
+          <Type>OFFOLLOWINGMONTH</Type>
+        </Sales>
+       </PaymentTerms>
     </Contact>
   </Contacts>
 </Response>

--- a/test/unit/models/bank_transaction_test.rb
+++ b/test/unit/models/bank_transaction_test.rb
@@ -6,8 +6,8 @@ class BankTransactionTest < Test::Unit::TestCase
   def setup
 
     the_line_items = [
-      LineItem.build({:quantity => 1, :tax_amount => 0.15, :unit_amount => 1.00, :tax_amount => 0.50}, nil),
-      LineItem.build({:quantity => 1, :tax_amount => 0.15, :unit_amount => 1.00, :tax_amount => 0.50}, nil)
+      LineItem.build({:quantity => 1, :unit_amount => 1.00, :tax_amount => 0.50}, nil),
+      LineItem.build({:quantity => 1, :unit_amount => 1.00, :tax_amount => 0.50}, nil)
     ]
 
     @the_bank_transaction = BankTransaction.new(nil)

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -5,22 +5,86 @@ class ContactTest < Test::Unit::TestCase
   
   def setup
     @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
-    @contact = @client.Contact.build
   end
   
   context "contact validators" do
-    
     should "have a name" do
-      assert_equal(false, @contact.valid?)
-      blank_error = @contact.errors_for(:name).first
+      contact = @client.Contact.build
+
+      assert_equal(false, contact.valid?)
+      blank_error = contact.errors_for(:name).first
       assert_not_nil(blank_error)
       assert_equal("can't be blank", blank_error)
       
-      @contact.name = "SOMETHING"
-      assert_equal(true, @contact.valid?)
-      assert_equal(0, @contact.errors.size)
+      contact.name = "SOMETHING"
+      assert_equal(true, contact.valid?)
+      assert_equal(0, contact.errors.size)
+    end
+  end
+
+  context "response parsing" do
+    it "parses default attributes" do 
+      @instance = Xeroizer::Record::ContactModel.new(nil, "Contact")
+
+      some_xml = get_record_xml("contact")
+
+      result = @instance.parse_response(some_xml)
+      contact = result.response_items.first
+
+      keys = [:contact_id,
+              :contact_status,
+              :name,
+              :first_name,
+              :last_name,
+              :email_address,
+              :skype_user_name,
+              :bank_account_details,
+              :tax_number,
+              :accounts_receivable_tax_type,
+              :accounts_payable_tax_type,
+              :addresses,
+              :phones,
+              :updated_date_utc,
+              :is_supplier,
+              :is_customer,
+              :default_currency]
+
+      assert_equal(contact.attributes.keys, keys)
     end
 
+    it "parses extra attributes when present" do
+      @instance = Xeroizer::Record::ContactModel.new(nil, "Contact")
+
+      some_xml = get_record_xml("contact_with_details")
+
+      result = @instance.parse_response(some_xml)
+      contact = result.response_items.first
+
+      keys = [:contact_id,
+              :contact_status,
+              :name,
+              :first_name,
+              :last_name,
+              :email_address,
+              :skype_user_name,
+              :bank_account_details,
+              :tax_number,
+              :accounts_receivable_tax_type,
+              :accounts_payable_tax_type,
+              :addresses,
+              :phones,
+              :updated_date_utc,
+              :is_supplier,
+              :is_customer,
+              :default_currency,
+              :balances]
+
+      assert_equal(contact.attributes.keys, keys)
+
+      assert_equal(contact.balances.accounts_receivable.outstanding, 849.50)
+      assert_equal(contact.balances.accounts_receivable.overdue, 910.00)
+      assert_equal(contact.balances.accounts_payable.outstanding, 0.00)
+      assert_equal(contact.balances.accounts_payable.overdue, 0.00)
+    end
   end
-  
 end

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -77,7 +77,8 @@ class ContactTest < Test::Unit::TestCase
               :is_supplier,
               :is_customer,
               :default_currency,
-              :balances]
+              :balances,
+              :batch_payments]
 
       assert_equal(contact.attributes.keys, keys)
 
@@ -85,6 +86,10 @@ class ContactTest < Test::Unit::TestCase
       assert_equal(contact.balances.accounts_receivable.overdue, 910.00)
       assert_equal(contact.balances.accounts_payable.outstanding, 0.00)
       assert_equal(contact.balances.accounts_payable.overdue, 0.00)
+
+      assert_equal(contact.batch_payments.bank_account_number, "123456")
+      assert_equal(contact.batch_payments.bank_account_name, "bank account")
+      assert_equal(contact.batch_payments.details, "details")
     end
   end
 end

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -78,7 +78,8 @@ class ContactTest < Test::Unit::TestCase
               :is_customer,
               :default_currency,
               :balances,
-              :batch_payments]
+              :batch_payments,
+              :payment_terms]
 
       assert_equal(contact.attributes.keys, keys)
 
@@ -90,6 +91,11 @@ class ContactTest < Test::Unit::TestCase
       assert_equal(contact.batch_payments.bank_account_number, "123456")
       assert_equal(contact.batch_payments.bank_account_name, "bank account")
       assert_equal(contact.batch_payments.details, "details")
+
+      assert_equal(contact.payment_terms.bills.day, "4")
+      assert_equal(contact.payment_terms.bills.type, "OFFOLLOWINGMONTH")
+      assert_equal(contact.payment_terms.sales.day, "2")
+      assert_equal(contact.payment_terms.sales.type, "OFFOLLOWINGMONTH")
     end
   end
 end


### PR DESCRIPTION
The Xero Api Contact endpoint returns additional data when performing a paginated or individual query (http://developer.xero.com/documentation/api/contacts/#GET). This PR aims to add support for accessing this data. Due to the formatting of the returned XML, it is not possible to handle it with the existing `has_many` relationship. 

```
#returned as part of Contact XML
<Balances>
  <AccountsReceivable>
    <Outstanding>849.50</Outstanding>
    <Overdue>910.00</Overdue>
  </AccountsReceivable>
  <AccountsPayable>
    <Outstanding>0.00</Outstanding>
    <Overdue>0.00</Overdue>
  </AccountsPayable>
</Balances>
```

However the `belongs_to` relationship does provide the right functionality, but has been aliased to `has_one` method name, as it describes the relationship more accurately (inspired by Active Record naming).

I would love to get some feedback on this approach and/or alternative suggestions of dealing with this.
Thanks!