### PR TITLE
Update to new Xero API url for sha2

### DIFF
--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -55,7 +55,7 @@ module Xeroizer
       # @see PrivateApplication
       # @see PartnerApplication
       def initialize(consumer_key, consumer_secret, options = {})
-        @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
+        @xero_url = options[:xero_url] || "https://sha2-api.xero.com/api.xro/2.0"
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
         @default_headers = options[:default_headers] || {}

--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -19,8 +19,8 @@ module Xeroizer
       # @return [PartnerApplication] instance of PrivateApplication
       def initialize(consumer_key, consumer_secret, path_to_private_key, ssl_client_cert, ssl_client_key, options = {})
         default_options = {
-          :xero_url         => 'https://api-partner.network.xero.com/api.xro/2.0',
-          :site             => 'https://api-partner.network.xero.com',
+          :xero_url         => 'https://sha2-api-partner.network.xero.com/api.xro/2.0',
+          :site             => 'https://sha2-api-partner.network.xero.com',
           :authorize_url    => 'https://api.xero.com/oauth/Authorize',
           :signature_method => 'RSA-SHA1'
         }


### PR DESCRIPTION
Only tested PrivateApplication which seems to be working fine for me.