### PR TITLE
Retry nonce used

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,25 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
                                          :rate_limit_sleep => 2)
 ```
 
+Xero API Nonce Used
+-------------------
+
+The Xero API seems to reject requests due to conflicts on occasion.
+
+By default, the library will raise a `Xeroizer::OAuth::NonceUsed`
+exception when one of these limits is exceeded.
+
+If required, the library can handle these exceptions internally by sleeping 1 second and then repeating the last request.
+You can set this option when initializing an application:
+
+```ruby
+# Sleep for 2 seconds every time the rate limit is exceeded.
+client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
+                                         YOUR_OAUTH_CONSUMER_SECRET,
+                                         :nonce_used_max_attempts => 3)
+```
+
+
 Logging
 ---------------
 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -7,7 +7,7 @@ module Xeroizer
     extend Record::ApplicationHelper
 
     attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts,
-                :default_headers, :unitdp, :before_request, :after_request
+                :default_headers, :unitdp, :before_request, :after_request, :nonce_used_max_attempts
 
     extend Forwardable
     def_delegators :client, :access_token
@@ -58,6 +58,7 @@ module Xeroizer
         @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
+        @nonce_used_max_attempts = options[:nonce_used_max_attempts] || 1
         @default_headers = options[:default_headers] || {}
         @before_request = options.delete(:before_request)
         @after_request = options.delete(:after_request)

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -121,6 +121,11 @@ module Xeroizer
             else
               handle_unknown_response_error!(response)
           end
+        rescue Xeroizer::OAuth::NonceUsed => exception
+          raise if attempts > nonce_used_max_attempts
+          logger.info("Nonce used: " + exception.to_s) if self.logger
+          sleep_for(1)
+          retry
         rescue Xeroizer::OAuth::RateLimitExceeded
           if self.rate_limit_sleep
             raise if attempts > rate_limit_max_attempts

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -157,6 +157,7 @@ module Xeroizer
             when "token_rejected"               then raise OAuth::TokenInvalid.new(description)
             when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
             when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
+            when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
             else raise OAuth::UnknownError.new(problem + ':' + description)
           end
         else

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -28,6 +28,7 @@ module Xeroizer
     class TokenInvalid < StandardError; end
     class RateLimitExceeded < StandardError; end
     class ConsumerKeyUnknown < StandardError; end
+    class NonceUsed < StandardError; end
     class UnknownError < StandardError; end
 
     unless defined? XERO_CONSUMER_OPTIONS

--- a/test/stub_responses/nonce_used
+++ b/test/stub_responses/nonce_used
@@ -1,0 +1,1 @@
+oauth_problem=nonce_used&oauth_problem_advice=The%20nonce%20value%20%22potatocakes%22%20has%20already%20been%20used%20

--- a/test/unit/oauth_test.rb
+++ b/test/unit/oauth_test.rb
@@ -32,7 +32,15 @@ class OAuthTest < Test::Unit::TestCase
         @client.Organisation.first
       end
     end
+
+    should "handle nonce used" do
+      Xeroizer::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("nonce_used"), :code => "401"))
       
+      assert_raises Xeroizer::OAuth::NonceUsed do
+        @client.Organisation.first
+      end
+    end
+
     should "raise rate limit exceeded" do
       Xeroizer::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("rate_limit_exceeded"), :code => "401"))
       

--- a/test/unit/oauth_test.rb
+++ b/test/unit/oauth_test.rb
@@ -73,7 +73,18 @@ class OAuthTest < Test::Unit::TestCase
         auto_rate_limit_client.Organisation.first
       end
     end
-      
+
+    should "retry nonce_used failures a configurable number of times" do
+      nonce_used_client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET, :nonce_used_max_attempts => 4)
+      Xeroizer::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("nonce_used"), :code => "401"))
+
+      nonce_used_client.expects(:sleep_for).with(1).times(4).returns(1)
+
+      assert_raises Xeroizer::OAuth::NonceUsed do
+        nonce_used_client.Organisation.first
+      end
+    end
+
     should "handle unknown errors" do
       Xeroizer::OAuth.any_instance.stubs(:get).returns(stub(:plain_body => get_file_as_string("bogus_oauth_error"), :code => "401"))
       


### PR DESCRIPTION
Addresses #260 by working around the Xero server side response in a similar way to rate limiting.

Later, might have to combine 'max attempts' for rate limiting and nonce used together.