### PR TITLE
Add support for Xero's new Organisation Offline API response

### DIFF
--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -163,6 +163,7 @@ module Xeroizer
             when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
             when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
             when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
+            when "organisation offline"         then raise OAuth::OrganisationOffline.new(description)
             else raise OAuth::UnknownError.new(problem + ':' + description)
           end
         else

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -29,6 +29,7 @@ module Xeroizer
     class RateLimitExceeded < StandardError; end
     class ConsumerKeyUnknown < StandardError; end
     class NonceUsed < StandardError; end
+    class OrganisationOffline < StandardError; end
     class UnknownError < StandardError; end
 
     unless defined? XERO_CONSUMER_OPTIONS


### PR DESCRIPTION
On May 28'th, Xero is starting maintenance and may make organisations unavailable to the API for a period of time. In preparation, Xero has introduced a new 503 error: `Organisation Offline`. Currently, Xeroizer will throw a `Xeroizer::OAuth::UnknownError` in response to this. 

This PR adds support for the new API response allowing connected applications to inform users appropriately when organisations are offline.
