### PR TITLE
Include PaymentTerms when getting paged Contacts

### DIFF
--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -41,7 +41,9 @@ module Xeroizer
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
       boolean       :is_supplier
       boolean       :is_customer
-      
+
+      belongs_to :payment_terms, :model_name => 'PaymentTerms', :complete_on_page => true
+
       has_many  :addresses, :list_complete => true
       has_many  :phones, :list_complete => true
       has_many  :contact_groups

--- a/lib/xeroizer/models/payment_terms.rb
+++ b/lib/xeroizer/models/payment_terms.rb
@@ -1,0 +1,13 @@
+module Xeroizer
+  module Record
+
+    class PaymentTermsModel < BaseModel
+    end
+    
+    class PaymentTerms < Base
+      belongs_to :bills, :model_name => 'PaymentTermsBills'
+      belongs_to :sales, :model_name => 'PaymentTermsSales'
+    end
+
+  end
+end

--- a/lib/xeroizer/models/payment_terms_bills.rb
+++ b/lib/xeroizer/models/payment_terms_bills.rb
@@ -1,0 +1,24 @@
+module Xeroizer
+  module Record
+
+    class PaymentTermsBillsModel < BaseModel
+      set_xml_node_name 'Bills'
+    end
+    
+    class PaymentTermsBills < Base
+
+      PAYMENT_TERMS_BILLS_TYPE = {
+        'OFFOLLOWINGMONTH'    => '',
+        'DAYSAFTERBILLDATE'   => '',
+        'DAYSAFTERBILLMONTH'  => '',
+        'OFCURRENTMONTH'      => ''
+        } unless defined?(PAYMENT_TERMS_BILLS_TYPE)
+      
+      string :day
+      string :type
+
+      validates_inclusion_of :type, :in => PAYMENT_TERMS_BILLS_TYPE.keys, :allow_blanks => true
+    end
+
+  end
+end

--- a/lib/xeroizer/models/payment_terms_sales.rb
+++ b/lib/xeroizer/models/payment_terms_sales.rb
@@ -1,0 +1,24 @@
+module Xeroizer
+  module Record
+
+    class PaymentTermsSalesModel < BaseModel
+      set_xml_node_name 'Sales'
+    end
+    
+    class PaymentTermsSales < Base
+
+      PAYMENT_TERMS_SALES_TYPE = {
+        'OFFOLLOWINGMONTH'    => '',
+        'DAYSAFTERBILLDATE'   => '',
+        'DAYSAFTERBILLMONTH'  => '',
+        'OFCURRENTMONTH'      => ''
+        } unless defined?(PAYMENT_TERMS_SALES_TYPE)
+      
+      string :day
+      string :type
+
+      validates_inclusion_of :type, :in => PAYMENT_TERMS_SALES_TYPE.keys, :allow_blanks => true
+    end
+
+  end
+end


### PR DESCRIPTION
In Xero API, when we can get paged Contacts that includes PaymentTerms (Sales and Bills). This one implements it here in Xeroizer.

Don't have an idea how to unit test it. But we're currently using it in our system.

Hope it'll help somebody.

P.S. First time to do pull request.