### PR TITLE
Require active_support/big_decimal/conversions instead of custom monkey patch

### DIFF
--- a/lib/big_decimal_to_s.rb
+++ b/lib/big_decimal_to_s.rb
@@ -1,9 +1,0 @@
-class BigDecimal
-  
-  def to_s_with_default_format(format = 'F')
-    to_s_without_default_format(format)
-  end
-  alias_method :to_s_without_default_format, :to_s
-  alias_method :to_s, :to_s_with_default_format
-  
-end

--- a/lib/xeroizer.rb
+++ b/lib/xeroizer.rb
@@ -3,6 +3,7 @@ require 'date'
 require 'forwardable'
 require 'active_support/inflector'
 require "active_support/core_ext/array"
+require "active_support/big_decimal/conversions"
 require 'oauth'
 require 'oauth/signature/rsa/sha1'
 require 'nokogiri'


### PR DESCRIPTION
This accomplishes the same thing as the monkey patch, but is better code because it is using Module.prepend.

Looks like this change is in one form or another since quite a ways back in Rails-land: rails/rails#621f48edb27022a0798d083e50339c552221d0bf.

Because you're depending on activesupport already in the gem, it's better to rely on their monkeypatch than a custom one that you'll need to maintain too.