### PR TITLE
Fix const_get inheritance issue in report factory

### DIFF
--- a/lib/xeroizer/report/factory.rb
+++ b/lib/xeroizer/report/factory.rb
@@ -35,7 +35,7 @@ module Xeroizer
 
         def klass
           begin
-            @_klass_cache ||= Xeroizer::Report.const_get(report_type)
+            @_klass_cache ||= Xeroizer::Report.const_get(report_type, false)
           rescue NameError => ex # use default class
             Base
           end

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+class MockNonReportClassDefinition; end
+
 class FactoryTest < Test::Unit::TestCase
   include TestHelper
   
@@ -128,7 +130,16 @@ class FactoryTest < Test::Unit::TestCase
     end
     
   end
-  
+
+  context "report factory in the dirty real world" do
+
+    should "not use inheritance to find report class" do
+      report = Xeroizer::Report::Factory.new(@client, :MockNonReportClassDefinition).klass
+      assert_equal(Xeroizer::Report::Base, report)
+    end
+
+  end
+
   private
   
     def check_valid_report_type(row)


### PR DESCRIPTION
`const_get` will return a class from the Object namespace unless you pass in false as the second param. This can cause conflicts with ActiveRecord models, etc.

i.e.

``` ruby
class TrialBalance; end

client.TrialBalance.get(:date => '2011-03-21') # NoMethodError
```
