### PR TITLE
Allow attachments to be opened in binary mode

### DIFF
--- a/lib/xeroizer/models/attachment.rb
+++ b/lib/xeroizer/models/attachment.rb
@@ -82,7 +82,7 @@ module Xeroizer
       def get(filename = nil)
         data = parent.application.http_get(parent.application.client, url)
         if filename
-          File.open(filename, "w") { | fp | fp.write data }
+          File.open(filename, "wb") { | fp | fp.write data }
           nil
         else
           data


### PR DESCRIPTION
Hi @waynerobinson by adding the binary mode it allows files of different formats to be opened. Thanks :)