### PR TITLE
Fix warnings: variables, not initialized or not set

### DIFF
--- a/lib/class_level_inheritable_attributes.rb
+++ b/lib/class_level_inheritable_attributes.rb
@@ -16,10 +16,13 @@ module ClassLevelInheritableAttributes
     end
     
     def inherited(subclass)
+      original_verbose, $VERBOSE = $VERBOSE, nil
       @xeroizer_inheritable_attributes.each do |inheritable_attribute|
         instance_var = "@#{inheritable_attribute}"
         subclass.instance_variable_set(instance_var, instance_variable_get(instance_var))
       end
+      $VERBOSE = original_verbose
+
     end
   end
 end

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -148,78 +148,78 @@ module Xeroizer
     end
 
     def handle_oauth_error!(response)
-        error_details = CGI.parse(response.plain_body)
-        description   = error_details["oauth_problem_advice"].first
-        problem = error_details["oauth_problem"].first
+      error_details = CGI.parse(response.plain_body)
+      description   = error_details["oauth_problem_advice"].first
+      problem = error_details["oauth_problem"].first
 
-        # see http://oauth.pbworks.com/ProblemReporting
-        # In addition to token_expired and token_rejected, Xero also returns
-        # 'rate limit exceeded' when more than 60 requests have been made in
-        # a second.
-        if problem
-          case (problem)
-            when "token_expired"                then raise OAuth::TokenExpired.new(description)
-            when "token_rejected"               then raise OAuth::TokenInvalid.new(description)
-            when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
-            when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
-            when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
-            else raise OAuth::UnknownError.new(problem + ':' + description)
-          end
-        else
-          raise OAuth::UnknownError.new("Xero API may be down or the way OAuth errors are provided by Xero may have changed.")
+      # see http://oauth.pbworks.com/ProblemReporting
+      # In addition to token_expired and token_rejected, Xero also returns
+      # 'rate limit exceeded' when more than 60 requests have been made in
+      # a second.
+      if problem
+        case (problem)
+          when "token_expired"                then raise OAuth::TokenExpired.new(description)
+          when "token_rejected"               then raise OAuth::TokenInvalid.new(description)
+          when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
+          when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
+          when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
+          else raise OAuth::UnknownError.new(problem + ':' + description)
         end
+      else
+        raise OAuth::UnknownError.new("Xero API may be down or the way OAuth errors are provided by Xero may have changed.")
+      end
+    end
+
+    def handle_error!(response, request_body)
+
+      raw_response = response.plain_body
+
+      # XeroGenericApplication API Exceptions *claim* to be UTF-16 encoded, but fail REXML/Iconv parsing...
+      # So let's ignore that :)
+      raw_response.gsub! '<?xml version="1.0" encoding="utf-16"?>', ''
+
+      # doc = REXML::Document.new(raw_response, :ignore_whitespace_nodes => :all)
+      doc = Nokogiri::XML(raw_response)
+
+      if doc && doc.root && doc.root.name == "ApiException"
+
+        raise ApiException.new(doc.root.xpath("Type").text,
+                               doc.root.xpath("Message").text,
+                               raw_response,
+                               doc,
+                               request_body)
+
+      else
+
+        raise BadResponse.new("Unparseable 400 Response: #{raw_response}")
+
       end
 
-      def handle_error!(response, request_body)
+    end
 
-        raw_response = response.plain_body
-
-        # XeroGenericApplication API Exceptions *claim* to be UTF-16 encoded, but fail REXML/Iconv parsing...
-        # So let's ignore that :)
-        raw_response.gsub! '<?xml version="1.0" encoding="utf-16"?>', ''
-
-        # doc = REXML::Document.new(raw_response, :ignore_whitespace_nodes => :all)
-        doc = Nokogiri::XML(raw_response)
-
-        if doc && doc.root && doc.root.name == "ApiException"
-
-          raise ApiException.new(doc.root.xpath("Type").text,
-                                 doc.root.xpath("Message").text,
-                                 raw_response,
-                                 doc,
-                                 request_body)
-
-        else
-
-          raise BadResponse.new("Unparseable 400 Response: #{raw_response}")
-
-        end
-
+    def handle_object_not_found!(response, request_url)
+      case(request_url)
+        when /Invoices/ then raise InvoiceNotFoundError.new("Invoice not found in Xero.")
+        when /CreditNotes/ then raise CreditNoteNotFoundError.new("Credit Note not found in Xero.")
+        else raise ObjectNotFound.new(request_url)
       end
+    end
 
-      def handle_object_not_found!(response, request_url)
-        case(request_url)
-          when /Invoices/ then raise InvoiceNotFoundError.new("Invoice not found in Xero.")
-          when /CreditNotes/ then raise CreditNoteNotFoundError.new("Credit Note not found in Xero.")
-          else raise ObjectNotFound.new(request_url)
-        end
-      end
+    def handle_unknown_response_error!(response)
+      raise BadResponse.new("Unknown response code: #{response.code.to_i}")
+    end
 
-      def handle_unknown_response_error!(response)
-        raise BadResponse.new("Unknown response code: #{response.code.to_i}")
-      end
+    def sleep_for(seconds = 1)
+      sleep seconds
+    end
 
-      def sleep_for(seconds = 1)
-        sleep seconds
-      end
-
-      # unitdp query string parameter to be added to request params
-      # when the application option has been set and the model has line items
-      # http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#unitamount
-      def unitdp_param(request_url)
-        models = [/Invoices/, /CreditNotes/, /BankTransactions/, /Receipts/]
-        self.unitdp == 4 && models.any?{ |m| request_url =~ m } ? {:unitdp => 4} : {}
-      end
+    # unitdp query string parameter to be added to request params
+    # when the application option has been set and the model has line items
+    # http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#unitamount
+    def unitdp_param(request_url)
+      models = [/Invoices/, /CreditNotes/, /BankTransactions/, /Receipts/]
+      self.unitdp == 4 && models.any?{ |m| request_url =~ m } ? {:unitdp => 4} : {}
+    end
 
   end
 end

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -37,7 +37,6 @@ module Xeroizer
       string        :last_name
       string        :email_address
       string        :skype_user_name
-      string        :contact_groups
       string        :default_currency
       string        :purchases_default_account_code
       string        :sales_default_account_code

--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -94,11 +94,11 @@ module Xeroizer
         # Calculate sub_total from line_items.
         def sub_total(always_summary = false)
           if !always_summary && (new_record? || (!new_record? && line_items && line_items.size > 0))
-            sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
+            overall_sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
             
             # If the default amount types are inclusive of 'tax' then remove the tax amount from this sub-total.
-            sum -= total_tax if line_amount_types == 'Inclusive' 
-            sum
+            overall_sum -= total_tax if line_amount_types == 'Inclusive' 
+            overall_sum
           else
             attributes[:sub_total]
           end

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -94,6 +94,12 @@ module Xeroizer
       validates_associated :line_items, :if => :approved?
 
       public
+        def initialize(parent)
+          super(parent)
+          @sub_total_is_set = false
+          @total_tax_is_set = false
+          @total_is_set = false
+        end
 
         # Access the contact name without forcing a download of
         # an incomplete, summary invoice.

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -146,11 +146,11 @@ module Xeroizer
         # Calculate sub_total from line_items.
         def sub_total(always_summary = false)
           if !@sub_total_is_set && not_summary_or_loaded_record(always_summary)
-            sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
+            overall_sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
 
             # If the default amount types are inclusive of 'tax' then remove the tax amount from this sub-total.
-            sum -= total_tax if line_amount_types == 'Inclusive'
-            sum
+            overall_sum -= total_tax if line_amount_types == 'Inclusive'
+            overall_sum
           else
             attributes[:sub_total]
           end

--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -22,7 +22,12 @@ module Xeroizer
       string  :line_item_id
       
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
-      
+
+      def initialize(parent)
+        super(parent)
+        @line_amount_set = false
+      end
+
       def line_amount=(line_amount)
         @line_amount_set = true
         attributes[:line_amount] = line_amount

--- a/lib/xeroizer/models/organisation.rb
+++ b/lib/xeroizer/models/organisation.rb
@@ -53,8 +53,6 @@ module Xeroizer
       string    :registration_number
       string    :timezone
       datetime_utc  :created_date_utc, :api_name => 'CreatedDateUTC'
-      string    :sales_tax_basis
-      string    :sales_tax_period
 
       has_many :addresses
       has_many :phones

--- a/lib/xeroizer/models/repeating_invoice.rb
+++ b/lib/xeroizer/models/repeating_invoice.rb
@@ -35,9 +35,10 @@ module Xeroizer
       string  :type
       string  :status
       string  :line_amount_types
-      decimal :sub_total, :calculated => true
-      decimal :total_tax, :calculated => true
-      decimal :total, :calculated => true
+      # TODO These are usually calculated fields, see Invoice.
+      decimal :sub_total
+      decimal :total_tax
+      decimal :total
       string  :currency_code
       boolean :has_attachments
 

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -75,6 +75,8 @@ module Xeroizer
         def initialize(application, model_name)
           @application = application
           @model_name = model_name
+          @allow_batch_operations = false
+          @objects = {}
         end
 
         # Retrieve the controller name.

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -72,169 +72,169 @@ module Xeroizer
 
       public
 
-        def initialize(application, model_name)
-          @application = application
-          @model_name = model_name
-          @allow_batch_operations = false
-          @objects = {}
+      def initialize(application, model_name)
+        @application = application
+        @model_name = model_name
+        @allow_batch_operations = false
+        @objects = {}
+      end
+
+      # Retrieve the controller name.
+      #
+      # Default: pluaralized model name (e.g. if the controller name is
+      # Invoice then the default is Invoices.
+      def api_controller_name
+        self.class.api_controller_name || model_name.pluralize
+      end
+
+      def model_class
+        @model_class ||= Xeroizer::Record.const_get(model_name.to_sym)
+      end
+
+      # Build a record with attributes set to the value of attributes.
+      def build(attributes = {})
+        model_class.build(attributes, self).tap do |resource|
+          mark_dirty(resource)
         end
+      end
 
-        # Retrieve the controller name.
-        #
-        # Default: pluaralized model name (e.g. if the controller name is
-        # Invoice then the default is Invoices.
-        def api_controller_name
-          self.class.api_controller_name || model_name.pluralize
+      def mark_dirty(resource)
+        if @allow_batch_operations
+          @objects[model_class] ||= {}
+          @objects[model_class][resource.object_id] ||= resource
         end
+      end
 
-        def model_class
-          @model_class ||= Xeroizer::Record.const_get(model_name.to_sym)
+      def mark_clean(resource)
+        if @objects and @objects[model_class]
+          @objects[model_class].delete(resource.object_id)
         end
+      end
 
-        # Build a record with attributes set to the value of attributes.
-        def build(attributes = {})
-          model_class.build(attributes, self).tap do |resource|
-            mark_dirty(resource)
-          end
-        end
+      # Create (build and save) a record with attributes set to the value of attributes.
+      def create(attributes = {})
+        build(attributes).tap { |resource| resource.save }
+      end
 
-        def mark_dirty(resource)
-          if @allow_batch_operations
-            @objects[model_class] ||= {}
-            @objects[model_class][resource.object_id] ||= resource
-          end
-        end
+      # Retreive full record list for this model.
+      def all(options = {})
+        raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
+        response_xml = http_get(parse_params(options))
+        response = parse_response(response_xml, options)
+        response.response_items || []
+      end
 
-        def mark_clean(resource)
-          if @objects and @objects[model_class]
-            @objects[model_class].delete(resource.object_id)
-          end
-        end
+      # Helper method to retrieve just the first element from
+      # the full record list.
+      def first(options = {})
+        raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
+        result = all(options)
+        result.first if result.is_a?(Array)
+      end
 
-        # Create (build and save) a record with attributes set to the value of attributes.
-        def create(attributes = {})
-          build(attributes).tap { |resource| resource.save }
-        end
+      # Retrieve record matching the passed in ID.
+      def find(id, options = {})
+        raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
+        response_xml = @application.http_get(@application.client, "#{url}/#{CGI.escape(id)}", options)
+        response = parse_response(response_xml, options)
+        result = response.response_items.first if response.response_items.is_a?(Array)
+        result.complete_record_downloaded = true if result
+        result
+      end
 
-        # Retreive full record list for this model.
-        def all(options = {})
-          raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
-          response_xml = http_get(parse_params(options))
-          response = parse_response(response_xml, options)
-          response.response_items || []
-        end
+      def save_records(records, chunk_size = DEFAULT_RECORDS_PER_BATCH_SAVE)
+        no_errors = true
+        return false unless records.all?(&:valid?)
 
-        # Helper method to retrieve just the first element from
-        # the full record list.
-        def first(options = {})
-          raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
-          result = all(options)
-          result.first if result.is_a?(Array)
-        end
-
-        # Retrieve record matching the passed in ID.
-        def find(id, options = {})
-          raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
-          response_xml = @application.http_get(@application.client, "#{url}/#{CGI.escape(id)}", options)
-          response = parse_response(response_xml, options)
-          result = response.response_items.first if response.response_items.is_a?(Array)
-          result.complete_record_downloaded = true if result
-          result
-        end
-
-        def save_records(records, chunk_size = DEFAULT_RECORDS_PER_BATCH_SAVE)
-          no_errors = true
-          return false unless records.all?(&:valid?)
-
-          actions = records.group_by {|o| o.new_record? ? create_method : :http_post }
-          actions.each_pair do |http_method, records_for_method|
-            records_for_method.each_slice(chunk_size) do |some_records|
-              request = to_bulk_xml(some_records)
-              response = parse_response(self.send(http_method, request, {:summarizeErrors => false}))
-              response.response_items.each_with_index do |record, i|
-                if record and record.is_a?(model_class)
-                  some_records[i].attributes = record.non_calculated_attributes
-                  some_records[i].errors = record.errors
-                  no_errors = record.errors.nil? || record.errors.empty? if no_errors
-                  some_records[i].saved!
-                end
+        actions = records.group_by {|o| o.new_record? ? create_method : :http_post }
+        actions.each_pair do |http_method, records_for_method|
+          records_for_method.each_slice(chunk_size) do |some_records|
+            request = to_bulk_xml(some_records)
+            response = parse_response(self.send(http_method, request, {:summarizeErrors => false}))
+            response.response_items.each_with_index do |record, i|
+              if record and record.is_a?(model_class)
+                some_records[i].attributes = record.non_calculated_attributes
+                some_records[i].errors = record.errors
+                no_errors = record.errors.nil? || record.errors.empty? if no_errors
+                some_records[i].saved!
               end
             end
           end
-
-          no_errors
         end
 
-        def batch_save(chunk_size = DEFAULT_RECORDS_PER_BATCH_SAVE)
+        no_errors
+      end
+
+      def batch_save(chunk_size = DEFAULT_RECORDS_PER_BATCH_SAVE)
+        @objects = {}
+        @allow_batch_operations = true
+
+        begin
+          yield
+
+          if @objects[model_class]
+            objects = @objects[model_class].values.compact
+            save_records(objects, chunk_size)
+          end
+        ensure
           @objects = {}
-          @allow_batch_operations = true
+          @allow_batch_operations = false
+        end
+      end
 
-          begin
-            yield
-
-            if @objects[model_class]
-              objects = @objects[model_class].values.compact
-              save_records(objects, chunk_size)
-            end
-          ensure
-            @objects = {}
-            @allow_batch_operations = false
+      def parse_response(response_xml, options = {})
+        Response.parse(response_xml, options) do | response, elements, response_model_name |
+          if model_name == response_model_name
+            @response = response
+            parse_records(response, elements, paged_records_requested?(options))
           end
         end
+      end
 
-        def parse_response(response_xml, options = {})
-          Response.parse(response_xml, options) do | response, elements, response_model_name |
-            if model_name == response_model_name
-              @response = response
-              parse_records(response, elements, paged_records_requested?(options))
-            end
-          end
-        end
-
-        def create_method
-          :http_put
-        end
+      def create_method
+        :http_put
+      end
 
       protected
 
 
-        def paged_records_requested?(options)
-          options.has_key?(:page) and options[:page].to_i >= 0
-        end
+      def paged_records_requested?(options)
+        options.has_key?(:page) and options[:page].to_i >= 0
+      end
 
 
       # Parse the records part of the XML response and builds model instances as necessary.
-        def parse_records(response, elements, paged_results)
-          elements.each do | element |
-            new_record = model_class.build_from_node(element, self)
-            if element.attribute('status').try(:value) == 'ERROR'
-              new_record.errors = []
-              element.xpath('.//ValidationError').each do |err|
-                new_record.errors << err.text.gsub(/^\s+/, '').gsub(/\s+$/, '')
-              end
+      def parse_records(response, elements, paged_results)
+        elements.each do | element |
+          new_record = model_class.build_from_node(element, self)
+          if element.attribute('status').try(:value) == 'ERROR'
+            new_record.errors = []
+            element.xpath('.//ValidationError').each do |err|
+              new_record.errors << err.text.gsub(/^\s+/, '').gsub(/\s+$/, '')
             end
-            new_record.paged_record_downloaded = paged_results
-            response.response_items << new_record
           end
-        end
-
-        def to_bulk_xml(records, builder = Builder::XmlMarkup.new(:indent => 2))
-          tag = (self.class.optional_xml_root_name || model_name).pluralize
-          builder.tag!(tag) do
-            records.each {|r| r.to_xml(builder) }
-          end
-        end
-
-        # Parse the response from a create/update request.
-        def parse_save_response(response_xml)
-          response = parse_response(response_xml)
-          record = response.response_items.first if response.response_items.is_a?(Array)
-          if record && record.is_a?(self.class)
-            @attributes = record.attributes
-          end
-          self
+          new_record.paged_record_downloaded = paged_results
+          response.response_items << new_record
         end
       end
 
+      def to_bulk_xml(records, builder = Builder::XmlMarkup.new(:indent => 2))
+        tag = (self.class.optional_xml_root_name || model_name).pluralize
+        builder.tag!(tag) do
+          records.each {|r| r.to_xml(builder) }
+        end
+      end
+
+      # Parse the response from a create/update request.
+      def parse_save_response(response_xml)
+        response = parse_response(response_xml)
+        record = response.response_items.first if response.response_items.is_a?(Array)
+        if record && record.is_a?(self.class)
+          @attributes = record.attributes
+        end
+        self
+      end
+    end
+    
   end
 end

--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -49,7 +49,7 @@ module Xeroizer
           options[:api_name] ||= field_name.to_s.camelize.gsub(/Id/, 'ID')
           define_simple_attribute(field_name, :guid, options)
         end
-              
+ 
         # Helper method to simplify field definition. 
         # Creates an accessor and reader for the field.
         # Options:
@@ -58,7 +58,8 @@ module Xeroizer
         #   :model_name => allows class used for children to be different from it's ndoe name in the XML.
         #   :type => type of field
         #   :skip_writer => skip the writer method
-        #   :calculated => only creates the field, no access (similar to :skip_writer)
+        #   :skip_reader => skip the reader method
+        #   :calculated => only creates the field, no access (similar to skip_writer: true, skip_reader: true)
         def define_simple_attribute(field_name, field_type, options, value_if_nil = nil)
           self.fields ||= {}
           
@@ -69,18 +70,18 @@ module Xeroizer
             :type           => field_type
           })
 
-          unless options[:calculated]
-            define_method internal_field_name do 
-              @attributes[field_name] || value_if_nil
-            end
-          end
-          
-          unless options[:skip_writer] || options[:calculated]
-            define_method "#{internal_field_name}=".to_sym do | value | 
-              parent.mark_dirty(self) if parent
-              @attributes[field_name] = value
-            end
-          end
+
+          # Users are expected to implement accessors for calculated methods
+          define_method internal_field_name do 
+            @attributes[field_name] || value_if_nil
+          end unless options[:calculated] || options[:skip_reader]
+
+
+          define_method "#{internal_field_name}=".to_sym do | value | 
+            parent.mark_dirty(self) if parent
+            @attributes[field_name] = value
+          end unless options[:calculated] || options[:skip_writer]
+
         end
         
       end

--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -58,6 +58,7 @@ module Xeroizer
         #   :model_name => allows class used for children to be different from it's ndoe name in the XML.
         #   :type => type of field
         #   :skip_writer => skip the writer method
+        #   :calculated => only creates the field, no access (similar to :skip_writer)
         def define_simple_attribute(field_name, field_type, options, value_if_nil = nil)
           self.fields ||= {}
           
@@ -67,11 +68,14 @@ module Xeroizer
             :api_name       => options[:api_name] || field_name.to_s.camelize,
             :type           => field_type
           })
-          define_method internal_field_name do 
-            @attributes[field_name] || value_if_nil
+
+          unless options[:calculated]
+            define_method internal_field_name do 
+              @attributes[field_name] || value_if_nil
+            end
           end
           
-          unless options[:skip_writer]
+          unless options[:skip_writer] || options[:calculated]
             define_method "#{internal_field_name}=".to_sym do | value | 
               parent.mark_dirty(self) if parent
               @attributes[field_name] = value

--- a/lib/xeroizer/record/validation_helper.rb
+++ b/lib/xeroizer/record/validation_helper.rb
@@ -64,7 +64,7 @@ module Xeroizer
         
         def errors_for(attribute)
           if errors.is_a?(Array)
-            errors.find_all { | (attr, msg) | attr == attribute }.map { | (attr, msg) | msg }
+            errors.find_all { | (attr, _) | attr == attribute }.map { | (_, msg) | msg }
           end
         end
         

--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -34,8 +34,8 @@ module Xeroizer
                   if element.element_children.size > 0
                     sub_field_name = field[:model_name] ? field[:model_name].to_sym : element.children.first.name.to_sym
                     sub_parent = record.new_model_class(sub_field_name)
-                    element.children.inject([]) do | list, element |
-                      list << Xeroizer::Record.const_get(sub_field_name).build_from_node(element, sub_parent)
+                    element.children.inject([]) do | list, inner_element |
+                      list << Xeroizer::Record.const_get(sub_field_name).build_from_node(inner_element, sub_parent)
                     end
                   end
 

--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -60,8 +60,8 @@ module Xeroizer
         
           # Turn a record into its XML representation.
           def to_xml(b = Builder::XmlMarkup.new(:indent => 2))
-            optional_root_tag(parent.class.optional_xml_root_name, b) do |b|
-              b.tag!(model.class.xml_node_name || model.model_name) {
+            optional_root_tag(parent.class.optional_xml_root_name, b) do |c|
+              c.tag!(model.class.xml_node_name || model.model_name) {
                 attributes.each do | key, value |
                   field = self.class.fields[key]
                   value = self.send(key) if field[:calculated]
@@ -82,7 +82,7 @@ module Xeroizer
           #   </Payments>
           def optional_root_tag(root_name, b, &block)
             if root_name
-              b.tag!(root_name) { |b| yield(b) }
+              b.tag!(root_name) { |c| yield(c) }
             else
               yield(b)
             end

--- a/lib/xeroizer/report/aged_receivables_by_contact.rb
+++ b/lib/xeroizer/report/aged_receivables_by_contact.rb
@@ -32,7 +32,6 @@ module Xeroizer
 
         def sum(column_name, &block)
           sections.first.rows.inject(BigDecimal.new('0')) do | sum, row |
-            cell = row.cell(column_name)
             sum += row.cell(column_name).value if row.class == Xeroizer::Report::Row && (block.nil? || block.call(row))
             sum
           end

--- a/lib/xeroizer/report/base.rb
+++ b/lib/xeroizer/report/base.rb
@@ -1,4 +1,3 @@
-require 'xeroizer/report/base'
 require 'xeroizer/report/cell'
 require 'xeroizer/report/row/row'
 require 'xeroizer/report/row/header'

--- a/lib/xeroizer/report/factory.rb
+++ b/lib/xeroizer/report/factory.rb
@@ -23,8 +23,8 @@ module Xeroizer
         # valid query-string parameters to pass to the API.
         def get(options = {})
           @response_xml = options[:cache_file] ? File.read(options[:cache_file]) : http_get(options)
-          response = Response.parse(response_xml, options) do | response, elements |
-            parse_reports(response, elements)
+          response = Response.parse(response_xml, options) do | inner_response, elements |
+            parse_reports(inner_response, elements)
           end
           response.response_items.first # there is is only one
         end

--- a/lib/xeroizer/report/factory.rb
+++ b/lib/xeroizer/report/factory.rb
@@ -36,7 +36,7 @@ module Xeroizer
         def klass
           begin
             @_klass_cache ||= Xeroizer::Report.const_get(report_type, false)
-          rescue NameError => ex # use default class
+          rescue NameError # use default class
             Base
           end
         end

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -53,10 +53,12 @@ class ContactTest < Test::Unit::TestCase
     end
 
     should "be able to have no name if has a contact_id" do
-      assert_equal(false, @contact.valid?)
-      @contact.contact_id = "1-2-3"
-      assert_equal(true, @contact.valid?)
-      assert_equal(0, @contact.errors.size)
+      contact = @client.Contact.build
+
+      assert_equal(false, contact.valid?)
+      contact.contact_id = "1-2-3"
+      assert_equal(true, contact.valid?)
+      assert_equal(0, contact.errors.size)
     end
 
     it "parses extra attributes when present" do

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -63,23 +63,23 @@ class FactoryTest < Test::Unit::TestCase
     end
     
     should "convert cells to BigDecimal where possible" do
-      counter = 0
-      @report.rows.each do |row|
-        if row.row? || row.summary?
-          row.cells.each do | cell |
-            counter += 1 if cell.value.is_a?(BigDecimal) && cell.value > 0
-          end
-        elsif row.section?
-          row.rows.each do | inner_row |
-            if inner_row.row? || inner_row.summary?
-              inner_row.cells.each do | cell | 
-                counter += 1 if cell.value.is_a?(BigDecimal) && cell.value > 0
-              end
-            end
-          end
-        end
+      def assess_row(row)
+        return 0 unless row.row? || row.summary?
+
+        row.cells.select {|cell| cell.value.is_a?(BigDecimal) && cell.value > 0}.length
       end
 
+      counter = 0
+
+      @report.rows.each do |row|
+        if row.section?
+          row.rows.each do |inner_row|
+            counter += assess_row(inner_row)
+          end
+        else
+          counter += assess_row(row)
+        end
+      end
       assert_not_equal(0, counter, "at least one converted number in the report should be greater than 0")
     end
     

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -63,7 +63,6 @@ class FactoryTest < Test::Unit::TestCase
     end
     
     should "convert cells to BigDecimal where possible" do
-      num_regex = /^[-]?\d+(\.\d+)?$/
       counter = 0
       @report.rows.each do | row |
         if row.row? || row.summary?

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -95,8 +95,8 @@ class FactoryTest < Test::Unit::TestCase
       @report.rows.each do | row |
         if row.type == 'Section'
           check_valid_report_type(row)
-          row.rows.each do | row |
-            check_valid_report_type(row)
+          row.rows.each do |inner_row|
+            check_valid_report_type(inner_row)
           end
         else
           check_valid_report_type(row)

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -64,21 +64,22 @@ class FactoryTest < Test::Unit::TestCase
     
     should "convert cells to BigDecimal where possible" do
       counter = 0
-      @report.rows.each do | row |
+      @report.rows.each do |row|
         if row.row? || row.summary?
           row.cells.each do | cell |
             counter += 1 if cell.value.is_a?(BigDecimal) && cell.value > 0
           end
         elsif row.section?
-          row.rows.each do | row |
-            if row.row? || row.summary?
-              row.cells.each do | cell | 
+          row.rows.each do | inner_row |
+            if inner_row.row? || inner_row.summary?
+              inner_row.cells.each do | cell | 
                 counter += 1 if cell.value.is_a?(BigDecimal) && cell.value > 0
               end
             end
           end
         end
       end
+
       assert_not_equal(0, counter, "at least one converted number in the report should be greater than 0")
     end
     


### PR DESCRIPTION
This isn't all of them, but it makes things look a lot less like:
```
bundle exec rake test:unit
...
./home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
/home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
/home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
/home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
/home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
./home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
/home/clockwerx/xeroizer/lib/xeroizer/record/base_model.rb:100: warning: instance variable @allow_batch_operations not initialized
```