### PR TITLE
include attachments to credit_notes - same as invoices

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -5,6 +5,8 @@ module Xeroizer
         
       set_permissions :read, :write, :update
       
+      include AttachmentModel::Extensions
+      
       public
 
         # Retrieve the PDF version of the credit matching the `id`.


### PR DESCRIPTION
Adds AttachmentModel::Extensions to CreditNoteModel, so I can attach PDFs to a CreditNote the same way I do Invoices.