### PR TITLE
Add 'around' callback to HTTP requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
 HTTP Callbacks
 --------------------
 
-You can provide "before" and "after" callbacks which will be invoked every
+You can provide "before", "after" and "around" callbacks which will be invoked every
 time Xeroizer makes an HTTP request, which is potentially useful for both
 throttling and logging:
 
@@ -631,6 +631,7 @@ Xeroizer::PublicApplication.new(
   credentials[:key], credentials[:secret],
   before_request: ->(request) { puts "Hitting this URL: #{request.url}" },
   after_request: ->(request, response) { puts "Got this response: #{response.code}" }
+  around_request: -> (request, &block)  { puts "About to send request"; block.call; puts "After request"}
 )
 ```
 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -7,7 +7,7 @@ module Xeroizer
     extend Record::ApplicationHelper
 
     attr_reader :client, :xero_url, :logger, :rate_limit_sleep, :rate_limit_max_attempts,
-                :default_headers, :unitdp, :before_request, :after_request, :nonce_used_max_attempts
+                :default_headers, :unitdp, :before_request, :after_request, :around_request, :nonce_used_max_attempts
 
     extend Forwardable
     def_delegators :client, :access_token
@@ -63,6 +63,7 @@ module Xeroizer
         @default_headers = options[:default_headers] || {}
         @before_request = options.delete(:before_request)
         @after_request = options.delete(:after_request)
+        @around_request = options.delete(:around_request)
         @client = OAuth.new(consumer_key, consumer_secret, options.merge({default_headers: default_headers}))
         @logger = options[:logger] || false
         @unitdp = options[:unitdp] || 2

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -98,10 +98,12 @@ module Xeroizer
 
           raw_body = params.delete(:raw_body) ? body : {:xml => body}
 
-          response = case method
-            when :get   then    client.get(uri.request_uri, headers)
-            when :post  then    client.post(uri.request_uri, raw_body, headers)
-            when :put   then    client.put(uri.request_uri, raw_body, headers)
+          response = with_around_request(request_info) do
+            case method
+              when :get   then    client.get(uri.request_uri, headers)
+              when :post  then    client.post(uri.request_uri, raw_body, headers)
+              when :put   then    client.put(uri.request_uri, raw_body, headers)
+            end
           end
 
           log_response(response, uri)
@@ -135,6 +137,14 @@ module Xeroizer
           else
             raise
           end
+        end
+      end
+
+      def with_around_request(request, &block)
+        if around_request
+          around_request.call(request, &block)
+        else
+          block.call
         end
       end
 


### PR DESCRIPTION
This adds an 'around' callback to complement the 'before' and 'after' callbacks added in #251.  We've been using this around callback in production for a while now, and is extremely useful for controlling rate-limiting etc.  We use it in conjunction with Sidekiq enterprise's rate limiting feature.  I'm sure others might find it useful as well!