### PR TITLE
Fix warnings - introduce a calculated flag

### DIFF
--- a/lib/xeroizer/models/repeating_invoice.rb
+++ b/lib/xeroizer/models/repeating_invoice.rb
@@ -35,9 +35,10 @@ module Xeroizer
       string  :type
       string  :status
       string  :line_amount_types
-      decimal :sub_total, :calculated => true
-      decimal :total_tax, :calculated => true
-      decimal :total, :calculated => true
+      # TODO These are usually calculated fields, see Invoice.
+      decimal :sub_total
+      decimal :total_tax
+      decimal :total
       string  :currency_code
       boolean :has_attachments
 

--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -49,7 +49,7 @@ module Xeroizer
           options[:api_name] ||= field_name.to_s.camelize.gsub(/Id/, 'ID')
           define_simple_attribute(field_name, :guid, options)
         end
-              
+ 
         # Helper method to simplify field definition. 
         # Creates an accessor and reader for the field.
         # Options:
@@ -58,7 +58,8 @@ module Xeroizer
         #   :model_name => allows class used for children to be different from it's ndoe name in the XML.
         #   :type => type of field
         #   :skip_writer => skip the writer method
-        #   :calculated => only creates the field, no access (similar to :skip_writer)
+        #   :skip_reader => skip the reader method
+        #   :calculated => only creates the field, no access (similar to skip_writer: true, skip_reader: true)
         def define_simple_attribute(field_name, field_type, options, value_if_nil = nil)
           self.fields ||= {}
           
@@ -69,18 +70,18 @@ module Xeroizer
             :type           => field_type
           })
 
-          unless options[:calculated]
-            define_method internal_field_name do 
-              @attributes[field_name] || value_if_nil
-            end
-          end
-          
-          unless options[:skip_writer] || options[:calculated]
-            define_method "#{internal_field_name}=".to_sym do | value | 
-              parent.mark_dirty(self) if parent
-              @attributes[field_name] = value
-            end
-          end
+
+          # Users are expected to implement accessors for calculated methods
+          define_method internal_field_name do 
+            @attributes[field_name] || value_if_nil
+          end unless options[:calculated] || options[:skip_reader]
+
+
+          define_method "#{internal_field_name}=".to_sym do | value | 
+            parent.mark_dirty(self) if parent
+            @attributes[field_name] = value
+          end unless options[:calculated] || options[:skip_writer]
+
         end
         
       end

--- a/lib/xeroizer/record/model_definition_helper.rb
+++ b/lib/xeroizer/record/model_definition_helper.rb
@@ -58,6 +58,7 @@ module Xeroizer
         #   :model_name => allows class used for children to be different from it's ndoe name in the XML.
         #   :type => type of field
         #   :skip_writer => skip the writer method
+        #   :calculated => only creates the field, no access (similar to :skip_writer)
         def define_simple_attribute(field_name, field_type, options, value_if_nil = nil)
           self.fields ||= {}
           
@@ -67,11 +68,14 @@ module Xeroizer
             :api_name       => options[:api_name] || field_name.to_s.camelize,
             :type           => field_type
           })
-          define_method internal_field_name do 
-            @attributes[field_name] || value_if_nil
+
+          unless options[:calculated]
+            define_method internal_field_name do 
+              @attributes[field_name] || value_if_nil
+            end
           end
           
-          unless options[:skip_writer]
+          unless options[:skip_writer] || options[:calculated]
             define_method "#{internal_field_name}=".to_sym do | value | 
               parent.mark_dirty(self) if parent
               @attributes[field_name] = value

--- a/lib/xeroizer/record/validation_helper.rb
+++ b/lib/xeroizer/record/validation_helper.rb
@@ -64,7 +64,7 @@ module Xeroizer
         
         def errors_for(attribute)
           if errors.is_a?(Array)
-            errors.find_all { | (attr, msg) | attr == attribute }.map { | (attr, msg) | msg }
+            errors.find_all { | (attr, _) | attr == attribute }.map { | (_, msg) | msg }
           end
         end
         

--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -34,8 +34,8 @@ module Xeroizer
                   if element.element_children.size > 0
                     sub_field_name = field[:model_name] ? field[:model_name].to_sym : element.children.first.name.to_sym
                     sub_parent = record.new_model_class(sub_field_name)
-                    element.children.inject([]) do | list, element |
-                      list << Xeroizer::Record.const_get(sub_field_name).build_from_node(element, sub_parent)
+                    element.children.inject([]) do | list, inner_element |
+                      list << Xeroizer::Record.const_get(sub_field_name).build_from_node(inner_element, sub_parent)
                     end
                   end
 


### PR DESCRIPTION
Continues on from #337 

Putting this one up for review/discussion as its a slight API change; as opposed to a one-liner.

Basically, we see warnings for attr_accessors being defined multiple times by the model, and then when we override it later on in the same class (mostly for calculated fields).

This adds in a 'calculated' flag, which avoids the warning by skipping field definitions (mostly bb850e2ce1d34293ce20f4e286219b19edb94172)

It also highlights that repeating invoices don't calculate a few things (13310df6e01a2b945509e1f415cdd3da57f92088)