### PR TITLE
adds length validators for addresses

### DIFF
--- a/lib/xeroizer/models/address.rb
+++ b/lib/xeroizer/models/address.rb
@@ -1,18 +1,18 @@
 module Xeroizer
   module Record
-    
+
     class AddressModel < BaseModel
-            
+
     end
-    
+
     class Address < Base
-      
+
       ADDRESS_TYPE = {
         'STREET' =>     'Street',
         'POBOX' =>      'PO Box',
         'DEFAULT' =>    'Default address type'
       } unless defined?(ADDRESS_TYPE)
-      
+
       string :address_type, :internal_name => :type
       string :attention_to
       string :address_line1, :internal_name => :line1
@@ -23,10 +23,19 @@ module Xeroizer
       string :region
       string :postal_code
       string :country
-      
+
       validates_inclusion_of :type, :in => ADDRESS_TYPE.keys
-      
+      validates_length_of :address_line1, :max => 500
+      validates_length_of :address_line2, :max => 500
+      validates_length_of :address_line3, :max => 500
+      validates_length_of :address_line4, :max => 500
+      validates_length_of :city, :max => 255
+      validates_length_of :region, :max => 255
+      validates_length_of :postal_code, :max => 50
+      validates_length_of :country, :max => 50
+      validates_length_of :attention_to, :max => 255
+
     end
-    
+
   end
 end

--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -60,6 +60,7 @@ module Xeroizer
 
       validates_presence_of :name, :unless => Proc.new { | contact | contact.contact_id.present?}
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true
+      validates_associated :addresses, allow_blanks: true
 
       def email_address?
         email_address.present?

--- a/test/unit/models/address_test.rb
+++ b/test/unit/models/address_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+class AddressTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
+    @contact = @client.Contact.build
+  end
+
+  def build_valid_address
+    @contact.add_address({
+      :type => "DEFAULT",
+      :address_line1 => "Baker street",
+      :address_line2 => "221",
+      :address_line3 => "Appartment: B",
+      :address_line4 => "abcdefgh",
+      :city => "London",
+      :region => "Marylebone",
+      :postal_code => "NW1 6XE",
+      :country => "UK",
+      :attention_to => "Mr Sherlock Holmes"
+    })
+  end
+
+  def generate_random_string(size)
+    charset = %w{A C D E F G H J K M N P Q R T V W X Y Z}
+    (0...size).map{ charset.to_a[rand(charset.size)] }.join
+  end
+
+   context "validators" do
+
+    should "allow valid address with valid attributes" do
+      address = build_valid_address
+      assert_equal(true, address.valid?)
+    end
+
+    should "not allow address_line1 to be longer than 500 characters" do
+      address = build_valid_address
+      address.line1 = generate_random_string(501)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow address_line2 to be longer than 500 characters" do
+      address = build_valid_address
+      address.line2 = generate_random_string(501)
+      assert_equal(false, address.valid?)
+    end
+    should "not allow address_line3 to be longer than 500 characters" do
+      address = build_valid_address
+      address.line3 = generate_random_string(501)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow address_line4 to be longer than 500 characters" do
+      address = build_valid_address
+      address.line4 = generate_random_string(501)
+      assert_equal(false, address.valid?)
+    end
+
+
+    should "not allow city to be longer than 255 characters" do
+      address = build_valid_address
+      address.city = generate_random_string(256)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow region to be longer than 255 characters" do
+      address = build_valid_address
+      address.region = generate_random_string(256)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow postal_code to be longer than 50 characters" do
+      address = build_valid_address
+      address.postal_code = generate_random_string(51)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow country to be longer than 50 characters" do
+      address = build_valid_address
+      address.country = generate_random_string(51)
+      assert_equal(false, address.valid?)
+    end
+
+    should "not allow attention_to to be longer than 255 characters" do
+      address = build_valid_address
+      address.attention_to = generate_random_string(256)
+      assert_equal(false, address.valid?)
+    end
+  end
+end

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -20,6 +20,20 @@ class ContactTest < Test::Unit::TestCase
       assert_equal(true, contact.valid?)
       assert_equal(0, contact.errors.size)
     end
+
+    should "not allow invalid addresses" do
+      contact = @client.Contact.build(name: "SOMETHING")
+      address = contact.add_address(:type => "INVALID_TYPE")
+
+      assert_equal(false, contact.valid?)
+      invalid_error = contact.errors_for(:addresses).first
+      assert_not_nil(invalid_error)
+      assert_equal("must all be valid", invalid_error)
+
+      address.type = "DEFAULT"
+      assert_equal(true, contact.valid?)
+      assert_equal(0, contact.errors.size)
+    end
   end
 
   context "response parsing" do


### PR DESCRIPTION
I noticed last week that a lot of our requests to Xero, to update addresses were failing.
After some digging in the Xero API docs I figured out that it had to do with the maximum length for address fields.
This pull requests adds validations to the address class to reflect the Xero API length limits (https://developer.xero.com/documentation/api/types#Addresses)