### PR TITLE
Expose OrganisationID on the Organisation object

### DIFF
--- a/lib/xeroizer/models/organisation.rb
+++ b/lib/xeroizer/models/organisation.rb
@@ -36,6 +36,7 @@ module Xeroizer
       string    :name
       string    :legal_name
       string    :short_code
+      string    :organisation_id
       boolean   :pays_tax
       string    :version
       string    :organisation_type


### PR DESCRIPTION
Change is to expose the unique identifier Xero provide for each organisation.

Couldn't find any minimum requirements for PRs in the project so please let me know if you need me to add/change anything.