### PR TITLE
Add planned payment date attribute to invoice

### DIFF
--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -78,6 +78,7 @@ module Xeroizer
       decimal      :currency_rate
       datetime     :fully_paid_on_date
       datetime     :expected_payment_date
+      datetime     :planned_payment_date
       boolean      :sent_to_contact
       boolean      :has_attachments
 


### PR DESCRIPTION
Adds the planned payment date attribute to the Xeroizer invoice model.