### PR TITLE
Allow invoices to be created with ContactNumber only

### DIFF
--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -58,7 +58,7 @@ module Xeroizer
       has_one :batch_payments, :model_name => 'BatchPayments', :list_complete => true
       has_one :payment_terms, :model_name => 'PaymentTerms', :list_complete => true
 
-      validates_presence_of :name, :unless => Proc.new { | contact | contact.contact_id.present?}
+      validates_presence_of :name, :unless => Proc.new { | contact | contact.contact_id.present? || contact.contact_number.present? }
       validates_inclusion_of :contact_status, :in => CONTACT_STATUS.keys, :allow_blanks => true
       validates_associated :addresses, allow_blanks: true
 

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -21,6 +21,15 @@ class ContactTest < Test::Unit::TestCase
       assert_equal(0, contact.errors.size)
     end
 
+    should "be able to have no name if it has a contact_number" do
+      contact = @client.Contact.build
+
+      assert_equal(false, contact.valid?)
+      contact.contact_number = "abc123"
+      assert_equal(true, contact.valid?)
+      assert_equal(0, contact.errors.size)
+    end
+
     should "not allow invalid addresses" do
       contact = @client.Contact.build(name: "SOMETHING")
       address = contact.add_address(:type => "INVALID_TYPE")

--- a/test/unit/models/contact_test.rb
+++ b/test/unit/models/contact_test.rb
@@ -21,6 +21,15 @@ class ContactTest < Test::Unit::TestCase
       assert_equal(0, contact.errors.size)
     end
 
+    should "be able to have no name if it has a contact_id" do
+      contact = @client.Contact.build
+
+      assert_equal(false, contact.valid?)
+      contact.contact_id = "1-2-3"
+      assert_equal(true, contact.valid?)
+      assert_equal(0, contact.errors.size)
+    end
+
     should "be able to have no name if it has a contact_number" do
       contact = @client.Contact.build
 
@@ -73,15 +82,6 @@ class ContactTest < Test::Unit::TestCase
               :default_currency]
 
       assert_equal(contact.attributes.keys, keys)
-    end
-
-    should "be able to have no name if has a contact_id" do
-      contact = @client.Contact.build
-
-      assert_equal(false, contact.valid?)
-      contact.contact_id = "1-2-3"
-      assert_equal(true, contact.valid?)
-      assert_equal(0, contact.errors.size)
     end
 
     it "parses extra attributes when present" do


### PR DESCRIPTION
Xero API allows invoices to be created when only `ContactNumber` is sent for the contact, without `Name`, but that fails Xeroizer's validation and it never makes a request to Xero API.

This relaxes the validation on contact name to allow this case to go through to the API, and let the API raise an error if contact with such `ContactNumber` doesn't exist.

There is also a minor change in unrelated test in a separate commit so you can choose if you want that too.