### PR TITLE
Fetch multiple records by IDs in one fetch

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -1,18 +1,18 @@
-require 'xeroizer/application_http_proxy' 
+require 'xeroizer/application_http_proxy'
 
 module Xeroizer
   module Record
     module BaseModelHttpProxy
-      
+
       def self.included(base)
         base.send :include, Xeroizer::ApplicationHttpProxy
         base.send :include, InstanceMethods
       end
-      
+
       module InstanceMethods
-        
+
         protected
-        
+
           # Parse parameters for GET requests.
           def parse_params(options)
             params = {}
@@ -20,9 +20,16 @@ module Xeroizer
             params[:includeArchived]  = options[:include_archived] if options[:include_archived]
             params[:order]        = options[:order] if options[:order]
 
+            if options[:IDs]
+              params[:IDs] =  case options[:IDs]
+                                when String   then options[:IDs]
+                                when Array    then options[:IDs].join(',')
+                              end
+            end
+
             if options[:where]
               params[:where] =  case options[:where]
-                                  when String   then options[:where] 
+                                  when String   then options[:where]
                                   when Hash     then parse_where_hash(options[:where])
                                 end
             end
@@ -30,7 +37,7 @@ module Xeroizer
             params[:page] = options[:page] if options[:page]
             params
           end
-        
+
           # Parse the :where part of the options for GET parameters and construct a valid
           # .Net version of the criteria to pass to Xero.
           #
@@ -46,14 +53,14 @@ module Xeroizer
               (attribute_name, expression) = extract_expression_from_attribute_name(key)
               (_, field) = model_class.fields.find { | k, v | v[:internal_name] == attribute_name }
               if field
-                conditions << where_condition_part(field, expression, value)                
+                conditions << where_condition_part(field, expression, value)
               else
                 raise InvalidAttributeInWhere.new(model_name, attribute_name)
               end
             end
             conditions.map { | (attr, expression, value) | "#{attr}#{expression}#{value}"}.join('&&')
           end
-        
+
           # Extract the attribute name and expression from the attribute.
           #
           # @return [Array] containing [actual_attribute_name, expression]
@@ -64,37 +71,37 @@ module Xeroizer
                   key.to_s.gsub(/(_is_not|\<\>)$/, '').to_sym,
                   '<>'
                 ]
-              
+
               when /(_is_greater_than|\>)$/
                 [
                   key.to_s.gsub(/(_is_greater_than|\>)$/, '').to_sym,
                   '>'
                 ]
-              
+
               when /(_is_greater_than_or_equal_to|\>\=)$/
                 [
                   key.to_s.gsub(/(_is_greater_than_or_equal_to|\>\=)$/, '').to_sym,
                   '>='
                 ]
-              
+
               when /(_is_less_than|\<)$/
                 [
                   key.to_s.gsub(/(_is_less_than|\<)$/, '').to_sym,
                   '<'
                 ]
-              
+
               when /(_is_less_than_or_equal_to|\<\=)$/
                 [
                   key.to_s.gsub(/(_is_less_than_or_equal_to|\<\=)$/, '').to_sym,
                   '<='
                 ]
-                              
+
               else
                 [key, '==']
-              
+
             end
           end
-        
+
           # Creates a condition part array containing the:
           #   * Field's API name
           #   * Expression
@@ -115,7 +122,7 @@ module Xeroizer
           end
 
       end
-    
+
     end
   end
 end

--- a/test/unit/record/parse_params_test.rb
+++ b/test/unit/record/parse_params_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+module Xeroizer
+  module Record
+
+    class ParseParamTestModel < BaseModel
+    end
+
+    class ParseParamTest < Base
+
+      set_primary_key :primary_key_id
+
+      guid      :primary_key_id
+      string    :string1
+      boolean   :boolean1
+      integer   :integer1
+      decimal   :decimal1
+      date      :date1
+      datetime  :datetime1
+
+    end
+
+  end
+end
+
+class ParseParamsTest < Test::Unit::TestCase
+  include TestHelper
+
+  def setup
+    @client = Xeroizer::PublicApplication.new(CONSUMER_KEY, CONSUMER_SECRET)
+    @model = Xeroizer::Record::ParseParamTestModel.new(@client, "ParseParamTest")
+  end
+
+  context "should return valid and filtered params" do
+    should "filter unsupported keys" do
+      params = @model.send(:parse_params, {
+        :should_be_filtered_out => 'should be filtered',
+        :modified_since => Date.parse("2010-01-05"),
+        :include_archived => true,
+        :order => :order,
+        :where => 'where string',
+        :IDs => ['29ed7958-0466-486d-bf57-3fd966ea37d7', 'd561892a-9023-498c-a28d-c626ed3940d8'],
+        :offset => 100,
+        :page => 2
+      })
+
+      params.assert_valid_keys(:ModifiedAfter, :includeArchived, :IDs, :order, :where, :offset, :page)
+      assert_equal(params[:IDs], '29ed7958-0466-486d-bf57-3fd966ea37d7,d561892a-9023-498c-a28d-c626ed3940d8')
+    end
+  end
+end


### PR DESCRIPTION
This pull requests addresses adding a list of IDs to fetch
(only currently supported by the Invoice and Contact
 endpoints)

For example only return two invoices specified
by ID
```
id_list = [
  '29ed7958-0466-486d-bf57-3fd966ea37d7',
  'd561892a-9023-498c-a28d-c626ed3940d8'
]
client.Invoice.all(:IDs => id_list).size # => 2
```