### PR TITLE
Cleanup line item test

### DIFF
--- a/test/unit/models/line_item_test.rb
+++ b/test/unit/models/line_item_test.rb
@@ -24,11 +24,8 @@ class LineItemTest < Test::Unit::TestCase
 
     line_item.quantity = 1
     line_item.unit_amount = BigDecimal("1337.00")
-    line_item.tax_amount = BigDecimal("0.15")
 
-    expected = BigDecimal((line_item.quantity * (line_item.unit_amount)).to_s).round(2)
-
-    assert_equal expected.to_s, line_item.line_amount.to_s,
+    assert_equal "1337.0", line_item.line_amount.to_s,
       "expected line_amount to equal unit_amount times quantity"
   end
 
@@ -36,12 +33,9 @@ class LineItemTest < Test::Unit::TestCase
     line_item = LineItem.new(nil)
     line_item.quantity = 1
     line_item.unit_amount = BigDecimal("1337.00")
-    line_item.tax_amount = BigDecimal("0.15")
-    line_item.discount_rate = BigDecimal("10.0")
+    line_item.discount_rate = BigDecimal("12.34")
 
-    discount = (100 - line_item.discount_rate) / 100
-    expected = BigDecimal(((line_item.quantity * line_item.unit_amount) * discount).to_s).round(2)
-    assert_equal expected.to_s, line_item.line_amount.to_s,
+    assert_equal "1172.01", line_item.line_amount.to_s,
       "expected line_amount to equal unit_amount times quantity minus the discount"
   end
 
@@ -50,20 +44,19 @@ class LineItemTest < Test::Unit::TestCase
 
     line_item.quantity = nil
     line_item.unit_amount = BigDecimal("1.00")
-    line_item.tax_amount = BigDecimal("0.15")
 
-    assert_equal "0.0", line_item.line_amount.to_s, "expected line amount zero when quantity is nil"
+    assert_equal "0.0", line_item.line_amount.to_s,
+      "expected line amount to be zero when quantity is nil"
 
     line_item.quantity = 0
-    assert_equal "0.0", line_item.line_amount.to_s, "expected line amount zero when quantity is zero"
+    assert_equal "0.0", line_item.line_amount.to_s,
+      "expected line amount to be zero when quantity is zero"
   end
 
   it "is not possible to set unit_amount to zero" do
     line_item = LineItem.new(nil)
 
-    line_item.quantity = 1
     line_item.unit_amount = nil
-    line_item.tax_amount = BigDecimal("0.15")
 
     assert_equal 0.0, line_item.unit_amount,
       "Expected setting unit_amount to nil to be ignored, i.e., it should remain zero"
@@ -74,11 +67,12 @@ class LineItemTest < Test::Unit::TestCase
 
     line_item.quantity = 1
     line_item.unit_amount = nil
-    line_item.tax_amount = BigDecimal("0.15")
 
-    assert_equal "0.0", line_item.line_amount.to_s, "expected line amount zero when unit_amount is nil"
+    assert_equal "0.0", line_item.line_amount.to_s,
+      "expected line amount to be zero when unit_amount is nil"
 
     line_item.unit_amount = BigDecimal("0.00")
-    assert_equal "0.0", line_item.line_amount.to_s, "expected line amount zero when unit_amount is zero"
+    assert_equal "0.0", line_item.line_amount.to_s,
+      "expected line amount to be zero when unit_amount is zero"
   end
 end


### PR DESCRIPTION
Main change here is switching form copying the code under test into test
itself to using literal expected values to compare the results retuned
by the code under test, which I think makes for a clearer test.

Also removed all calls to `line_item.tax_amount=`, as that is not
relevant to any of the tests.

Plus a few cosmetic changes to test failure messages.