### PR TITLE
Coerce decimals when calculating line amount

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -39,7 +39,7 @@ module Xeroizer
         return attributes[:line_amount] if summary_only || @line_amount_set
 
         if quantity && unit_amount
-          total = quantity * unit_amount
+          total = coerce_numeric(quantity) * coerce_numeric(unit_amount)
           if discount_rate
             BigDecimal((total * ((100 - discount_rate) / 100)).to_s).round(2)
           else
@@ -48,7 +48,14 @@ module Xeroizer
         end
       end
 
+      private
+
+      def coerce_numeric(number)
+        return number if number.is_a? Numeric
+        BigDecimal(number)
+      end
+
     end
-    
+
   end
 end

--- a/test/unit/models/line_item_test.rb
+++ b/test/unit/models/line_item_test.rb
@@ -75,4 +75,12 @@ class LineItemTest < Test::Unit::TestCase
     assert_equal "0.0", line_item.line_amount.to_s,
       "expected line amount to be zero when unit_amount is zero"
   end
+
+  it "coerces decimals when calculating line amount" do
+    line_item = LineItem.new(nil)
+    line_item.quantity = "1"
+    line_item.unit_amount = 50
+    assert_equal 50, line_item.line_amount,
+      "expected line amount to be calculated from coerced values"
+  end
 end


### PR DESCRIPTION
This is particularly important because String * Numeric has valid (but
very surprising) results. If quantity is supplied as a string, and
unit_amount as a numeric, line_amount will be successfully but
incorrectly calculated. e.g.

"1" * 12 # => "111111111111"

This subsequently gets coerced into a BigDecimal before being returned.

Ideally, type coercion or checking should happen at the interface of
the class, but this is the safest change to make at the moment.