### PR TITLE
Allow all currently supported filtering params

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -20,12 +20,10 @@ module Xeroizer
             params[:includeArchived]  = options[:include_archived] if options[:include_archived]
             params[:order]        = options[:order] if options[:order]
 
-            if options[:IDs]
-              params[:IDs] =  case options[:IDs]
-                                when String   then options[:IDs]
-                                when Array    then options[:IDs].join(',')
-                              end
-            end
+            params[:IDs]            = filterize(options[:IDs]) if options[:IDs]
+            params[:InvoiceNumbers] = filterize(options[:InvoiceNumbers]) if options[:InvoiceNumbers]
+            params[:ContactIDs]     = filterize(options[:ContactIDs]) if options[:ContactIDs]
+            params[:Statuses]       = filterize(options[:Statuses]) if options[:Statuses]
 
             if options[:where]
               params[:where] =  case options[:where]
@@ -118,6 +116,16 @@ module Xeroizer
               when :datetime_utc then [field[:api_name], expression, "DateTime.Parse(\"#{value.utc.strftime("%Y-%m-%dT%H:%M:%S")}\")"]
               when :belongs_to  then
               when :has_many    then
+            end
+          end
+
+        private
+
+          # Filtering params expect a comma separated list of strings 
+          def filterize(values)
+            case values
+              when String then values
+              when Array  then values.join(',')
             end
           end
 

--- a/test/unit/record/parse_params_test.rb
+++ b/test/unit/record/parse_params_test.rb
@@ -40,12 +40,20 @@ class ParseParamsTest < Test::Unit::TestCase
         :order => :order,
         :where => 'where string',
         :IDs => ['29ed7958-0466-486d-bf57-3fd966ea37d7', 'd561892a-9023-498c-a28d-c626ed3940d8'],
+        :InvoiceNumbers => 'INV-0034,INV-0035,INV-0036,INV-0037',
+        :ContactIDs => 'b919a496-1a1c-4fc6-b6ef-8c561e0dd8c2,8289cca4-90a9-466b-95f3-f0adf351b2ac',
+        :Statuses => ['DRAFT', nil, 'SUBMITTED'],
         :offset => 100,
         :page => 2
       })
 
-      params.assert_valid_keys(:ModifiedAfter, :includeArchived, :IDs, :order, :where, :offset, :page)
+      params.assert_valid_keys(:ModifiedAfter, :includeArchived, :order, :where,
+                               :IDs, :InvoiceNumbers, :ContactIDs, :Statuses,
+                               :offset, :page)
       assert_equal(params[:IDs], '29ed7958-0466-486d-bf57-3fd966ea37d7,d561892a-9023-498c-a28d-c626ed3940d8')
+      assert_equal(params[:InvoiceNumbers], 'INV-0034,INV-0035,INV-0036,INV-0037')
+      assert_equal(params[:ContactIDs], 'b919a496-1a1c-4fc6-b6ef-8c561e0dd8c2,8289cca4-90a9-466b-95f3-f0adf351b2ac')
+      assert_equal(params[:Statuses], 'DRAFT,,SUBMITTED')
     end
   end
 end


### PR DESCRIPTION
This expands on #386 to allow filtering by all currently supported params.

Params added in this pull request are supported by the Invoice endpoint only, yet they are globally available, for all Xeroizer models. This is the same issue previously raised by @CloCkWeRX in #386.