### PR TITLE
branding theme should be allowed on credit note

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -51,6 +51,7 @@ module Xeroizer
       guid          :credit_note_id
       string        :credit_note_number
       string        :reference
+      guid          :branding_theme_id
       string        :type
       date          :date
       date          :due_date


### PR DESCRIPTION
Hello, 

Per the API docs.  BrandingThemeId is a valid attribute on CreditNote

https://developer.xero.com/documentation/api/credit-notes

I have added that to this PR

Cheers, 
Scott