### PR TITLE
Expand list of endpoints eligible for unitdp param

### DIFF
--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -223,9 +223,9 @@ module Xeroizer
 
     # unitdp query string parameter to be added to request params
     # when the application option has been set and the model has line items
-    # http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#unitamount
+    # https://developer.xero.com/documentation/api-guides/rounding-in-xero#unitamount
     def unitdp_param(request_url)
-      models = [/Invoices/, /CreditNotes/, /BankTransactions/, /Receipts/]
+      models = [/Invoices/, /CreditNotes/, /BankTransactions/, /Receipts/, /Items/, /Overpayments/, /Prepayments/]
       self.unitdp == 4 && models.any?{ |m| request_url =~ m } ? {:unitdp => 4} : {}
     end
 


### PR DESCRIPTION
These are the endpoints that are documented to accept `unitdp` param.


On the other hand, how about removing this whitelist and just blindly appending `unitdp` to everything? I didn't try it, but I guess Xero will just ignore it on the endpoints that don't support it.

That kind of fits into a more general topic about doing more or less validation in Xeroizer, like discussed in #399.