### PR TITLE
Added `#save!` method

### DIFF
--- a/lib/xeroizer/exceptions.rb
+++ b/lib/xeroizer/exceptions.rb
@@ -97,6 +97,8 @@ module Xeroizer
     
   end
 
+  class RecordInvalid < XeroizerError; end
+
   class SettingTotalDirectlyNotSupported < XeroizerError
     
     def initialize(attribute_name)

--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -105,12 +105,20 @@ module Xeroizer
         end
 
         def save
-          return false unless valid?
+          save!
+          true
+        rescue XeroizerError
+          false
+        end
+
+        def save!
+          raise RecordInvalid unless valid?
           if new_record?
             create
           else
             update
           end
+
           saved!
         end
 

--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -107,7 +107,8 @@ module Xeroizer
         def save
           save!
           true
-        rescue XeroizerError
+        rescue XeroizerError => e
+          log "[ERROR SAVING] (#{__FILE__}:#{__LINE__}) - #{e.message}"
           false
         end
 

--- a/test/unit/oauth_test.rb
+++ b/test/unit/oauth_test.rb
@@ -99,7 +99,7 @@ class OAuthTest < Test::Unit::TestCase
       
       assert_raises Xeroizer::ApiException do
         contact = @client.Contact.build(:name => 'Test Contact')
-        contact.save
+        contact.save!
       end
     end
     
@@ -109,7 +109,7 @@ class OAuthTest < Test::Unit::TestCase
       
       assert_raises Xeroizer::UnparseableResponse do
         contact = @client.Contact.build(:name => 'Test Contact')
-        contact.save
+        contact.save!
       end      
     end
     


### PR DESCRIPTION
This makes Xeroizer models behave in a similar fassion to ActiveRecord. The existing `save` method has been changed to only ever return a boolean value, and a new `save!` method has been introduced so always raise an exception in the event of a failure or invalid record.

Fix for issue #402