### PR TITLE
added support for invoice GET param createdByMyApp

### DIFF
--- a/lib/xeroizer/record/base_model_http_proxy.rb
+++ b/lib/xeroizer/record/base_model_http_proxy.rb
@@ -19,6 +19,7 @@ module Xeroizer
             params[:ModifiedAfter]  = options[:modified_since] if options[:modified_since]
             params[:includeArchived]  = options[:include_archived] if options[:include_archived]
             params[:order]        = options[:order] if options[:order]
+            params[:createdByMyApp] = options[:createdByMyApp] if options[:createdByMyApp]
 
             params[:IDs]            = filterize(options[:IDs]) if options[:IDs]
             params[:InvoiceNumbers] = filterize(options[:InvoiceNumbers]) if options[:InvoiceNumbers]


### PR DESCRIPTION
Added support for the invoice GET param createdByMyApp

Usage
```ruby
invoices = xero.Invoice.all
invoice.count
# 197

invoices = xero.Invoice.all(:createdbyMyApp => true)
invoices.count
# 4
```
Number of invoices returned will be different for you, but you get the point.