### PR TITLE
removed unit price from inventory items (now under sales/purchase det…

### DIFF
--- a/lib/xeroizer/models/item.rb
+++ b/lib/xeroizer/models/item.rb
@@ -18,7 +18,6 @@ module Xeroizer
       string  :purchase_description
       string  :name
 
-      decimal :unit_price
       decimal :total_cost_pool # read only
       decimal :quantity_on_hand # read only
 


### PR DESCRIPTION
Removed UnitPrice from Items.

UnitPrice is now (and has been for a while) under SalesDetails / PurchaseDetails.

Documentation: https://developer.xero.com/documentation/api/items