### PR TITLE
raise undefined method error on build with useful message

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -30,7 +30,7 @@ module Xeroizer
         def build(attributes, parent)
           record = new(parent)
           attributes.each do | key, value |
-            attr = record.respond_to?("#{key}=") ? key : record.class.fields[key][:internal_name]
+            attr = record.respond_to?("#{key}=") || record.class.fields[key].nil? ? key : record.class.fields[key][:internal_name]
             record.send("#{attr}=", value)
           end
           record

--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -104,6 +104,16 @@ class RecordBaseTest < Test::Unit::TestCase
     end
   end
 
+  context 'build' do
+
+    should "raise an undefined method error with useful message" do
+      assert_raise_message("undefined method `this_method_does_not_exist=' for #<Xeroizer::Record::Contact >") do
+        @client.Contact.build(:this_method_does_not_exist =>  true)
+      end
+    end
+
+  end
+
   context 'saving' do
     context 'invalid record' do
       setup do


### PR DESCRIPTION
Hi, I added a small change so that when you use `build` any unknown attributes will raise a more useful error. 

example:
```
@client.Contact.build(:this_method_does_not_exist =>  true)

=> raises "undefined method `this_method_does_not_exist=' for #<Xeroizer::Record::Contact >"
```