### PR TITLE
Minor typo in README comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ invoice.save
 # An invoice created without a status will default to 'DRAFT'
 invoice.approved?
 
-# Payments can only be created against 'AUTHROISED' invoices
+# Payments can only be created against 'AUTHORISED' invoices
 invoice.approve!
 
 # Find the first bank account


### PR DESCRIPTION
Thanks very much for writing this - we're about to use it on a project. I was reviewing the documentation and found this minor typo.