### PR TITLE
Tests should be run against Demo Company (AU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ This option adds the unitdp=4 query string parameter to all requests for models 
 Tests
 -----
 
-The tests within the repository can be run by setting up a [Private App](https://developer.xero.com/documentation/auth-and-limits/private-applications).  You can create a Private App in the [developer portal](https://developer.xero.com/myapps/), it's suggested that you create it against the [Demo Company](https://developer.xero.com/documentation/getting-started/development-accounts) (note: the Demo Company expires after 28 days, so you will need to reset it and create a new Private App if you Demo Company has expired).
+The tests within the repository can be run by setting up a [Private App](https://developer.xero.com/documentation/auth-and-limits/private-applications).  You can create a Private App in the [developer portal](https://developer.xero.com/myapps/), it's suggested that you create it against the [Demo Company (AU)](https://developer.xero.com/documentation/getting-started/development-accounts). Demo Company expires after 28 days, so you will need to reset it and create a new Private App if you Demo Company has expired. Make sure you create the Demo Company in Australia region.
 
 Once you have created your Private App, set these environment variables:
 ```

--- a/test/acceptance/about_fetching_bank_transactions_test.rb
+++ b/test/acceptance/about_fetching_bank_transactions_test.rb
@@ -18,7 +18,7 @@ class AboutFetchingBankTransactions < Test::Unit::TestCase
       keys = [:line_amount_types, :contact, :date, :status, :line_items,
               :updated_date_utc, :currency_code, :bank_transaction_id,
               :bank_account, :type, :reference, :is_reconciled, :currency_rate]
-      assert_equal(@a_new_bank_transaction.attributes.keys, keys)
+      assert_equal(keys, @a_new_bank_transaction.attributes.keys)
     end
 
     it "returns full line item details" do
@@ -38,7 +38,7 @@ class AboutFetchingBankTransactions < Test::Unit::TestCase
       keys = [:line_amount_types, :contact, :date, :status, :updated_date_utc, 
               :currency_code, :bank_transaction_id, :bank_account, :type, :reference, 
               :is_reconciled]
-      assert_equal(@the_first_bank_transaction.attributes.keys, keys)
+      assert_equal(keys, @the_first_bank_transaction.attributes.keys)
     end
 
     it "returns contact" do


### PR DESCRIPTION
I initially ran the tests against Demo Company (UK) and got a failure in `about_fetching_bank_transactions_test.rb` where `:reference` key was "added" according to the test failure diff. But it was in fact missing from Xero response, but order of arguments to `assert_equal` was reversed, so that's why the diff was wrong.

In any case, switching to Australian Xero Demo Company solved this issue, so that's why I added this note to the readme.