### PR TITLE
Leave Time in local time zone

### DIFF
--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -106,7 +106,7 @@ module Xeroizer
               when :date
                 real_value = case value
                   when Date         then value.strftime("%Y-%m-%d")
-                  when Time         then value.utc.strftime("%Y-%m-%d")
+                  when Time         then value.strftime("%Y-%m-%d")
                   when NilClass     then nil
                   else raise ArgumentError.new("Expected Date or Time object for the #{field[:api_name]} field")
                 end


### PR DESCRIPTION
I've been on a bit of a quest to figure out how to convert UTC timestamps into the correct dates for invoices and payments. I'd tried using time zone hash I'd posted on https://github.com/waynerobinson/xeroizer/issues/458 along with Rails' time zone extensions to set the dates to a `Time` in the organization's time zone assuming that would end up as the correct... but strangely it kept using the UTC time... eventually I found where the `Time`s and `Date`s are serialized into XML and discovered my hard work was being undone.

Since Xero doesn't use any time or time zone component for it's date fields I don't think we should be converting them to UTC before saving them. So this PR removes that.

My temporary work around is put the Time into the right time zone then call `to_date` so there's no further conversion before it's serialized into XML.

