### PR TITLE
Fix PurchaseOrder model datatypes

### DIFF
--- a/lib/xeroizer/models/purchase_order.rb
+++ b/lib/xeroizer/models/purchase_order.rb
@@ -30,14 +30,14 @@ module Xeroizer
       boolean :is_discounted 
       string  :reference
       string  :type
-      string  :currency_rate
+      decimal  :currency_rate
       string  :currency_code
       guid  :branding_theme_id 
       string  :status 
       string  :line_amount_types
-      string  :sub_total
-      string  :total_tax
-      string  :total 
+      decimal  :sub_total
+      decimal  :total_tax
+      decimal  :total 
       date    :updated_date_UTC
       boolean :has_attachments
 


### PR DESCRIPTION
currency_rate, sub_total, total_tax and total should be decimals not strings