### PR TITLE
Support for Payment Service API endpoint

### DIFF
--- a/lib/xeroizer/models/branding_theme.rb
+++ b/lib/xeroizer/models/branding_theme.rb
@@ -5,33 +5,25 @@ module Xeroizer
 
     class BrandingThemeModel < BaseModel
 
+      module Extensions
+        def payment_services(branding_theme_id)
+          parent.payment_services(branding_theme_id)
+        end
+
+        def add_payment_service(branding_theme_id, payment_service_id)
+          parent.add_payment_service(branding_theme_id, payment_service_id)
+        end
+      end
+
       set_permissions :read, :write
 
-      public
-
-      def payment_services(id)
-        @payment_services ||= @application.http_get(@application.client, payment_services_endpoint(id))
-      end
-
-      def add_payment_service(id:, payment_service_id:)
-        xml = {
-          PaymentService: {
-            PaymentServiceID: payment_service_id
-          }
-        }.to_xml
-
-        @application.http_post(@application.client, payment_services_endpoint(id), xml)
-      end
-
-      private
-
-      def payment_services_endpoint(id)
-        "#{url}/#{id}/PaymentServices"
-      end
+      include PaymentServiceModel::Extensions
 
     end
 
     class BrandingTheme < Base
+
+      include PaymentServiceModel::Extensions
 
       set_primary_key :branding_theme_id
 
@@ -40,23 +32,17 @@ module Xeroizer
       integer   :sort_order
       datetime_utc  :created_date_utc, :api_name => 'CreatedDateUTC'
 
-      # Unfortunately, this part of the API does not work the same as the rest.
-      # You cannot POST child records to Branding Themes.
-      #
-      # The endpoints are:
-      # GET /BrandingThemes/{BrandingThemeID}/PaymentServices
-      # POST /BrandingThemes/{BrandingThemeID}/PaymentServices
-      #
-      # has_one :payment_service, :model_name => 'PaymentService', :list_complete => true
-
+      # Use this method to retrieve the payment services applied to a branding theme.
+      # GET https://api.xero.com/api.xro/2.0/BrandingThemes/{BrandingThemeID}/PaymentServices
       def payment_services
-        parent.payment_services(id)
+        parent.payment_services(branding_theme_id)
       end
 
+      # Use this method to apply a payment service to a branding theme
+      # POST https://api.xero.com/api.xro/2.0/BrandingThemes/{BrandingThemeID}/PaymentServices
       def add_payment_service(payment_service_id)
-        parent.add_payment_service(id: id, payment_service_id: payment_service_id)
+        parent.add_payment_service(branding_theme_id, payment_service_id)
       end
     end
-
   end
 end

--- a/lib/xeroizer/models/payment_service.rb
+++ b/lib/xeroizer/models/payment_service.rb
@@ -3,7 +3,51 @@ module Xeroizer
 
     class PaymentServiceModel < BaseModel
 
+      module Extensions
+        def payment_services(branding_theme_id)
+          application.PaymentService.payment_services(branding_theme_id)
+        end
+
+        def add_payment_service(branding_theme_id, payment_service_id)
+          application.PaymentService.add_payment_service(branding_theme_id, payment_service_id)
+        end
+      end
+
       set_permissions :read, :write, :update
+
+      def payment_services(branding_theme_id)
+        response_xml = @application.http_get(@application.client, payment_services_endpoint(branding_theme_id))
+        response = parse_response(response_xml)
+
+        if (response_items = response.response_items) && response_items.size > 0
+          response_items
+        else
+          []
+        end
+      end
+
+      def add_payment_service(branding_theme_id, payment_service_id)
+        xml = {
+          PaymentService: {
+            PaymentServiceID: payment_service_id
+          }
+        }.to_xml
+
+        response_xml = @application.http_post(@application.client, payment_services_endpoint(branding_theme_id), xml)
+        response = parse_response(response_xml)
+
+        if (response_items = response.response_items) && response_items.size > 0
+          response_items
+        else
+          []
+        end
+      end
+
+      private
+
+      def payment_services_endpoint(branding_theme_id)
+        "#{@application.xero_url}/BrandingThemes/#{CGI.escape(branding_theme_id)}/PaymentServices"
+      end
 
     end
 


### PR DESCRIPTION
1. Wrapper methods for Payment Service API
2. Attach Payment Service to Branding Theme via the endpoints below:
  a. GET /BrandingThemes/{BrandingThemeID}/PaymentServices
  b. POST /BrandingThemes/{BrandingThemeID}/PaymentServices
3. Parse XML and create appropriate `Xeroizer::Record` objects for Branding Theme as well as Payment Service API response.