### PR TITLE
Capture prepayments and applied_amount when an Invoice has had prepayments applied

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -66,6 +66,7 @@ module Xeroizer
       datetime      :fully_paid_on_date
       boolean       :sent_to_contact
       decimal       :remaining_credit
+      decimal       :applied_amount
       boolean       :has_attachments
 
       belongs_to    :contact

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -89,6 +89,7 @@ module Xeroizer
       has_many     :line_items, :complete_on_page => true
       has_many     :payments
       has_many     :credit_notes
+      has_many     :prepayments
 
       validates_presence_of :date, :due_date, :unless => :new_record?
       validates_inclusion_of :type, :in => INVOICE_TYPES

--- a/lib/xeroizer/models/prepayment.rb
+++ b/lib/xeroizer/models/prepayment.rb
@@ -25,6 +25,7 @@ module Xeroizer
       string        :reference
       decimal       :currency_rate
       decimal       :remaining_credit
+      decimal       :applied_amount
       boolean       :has_attachments
 
       belongs_to    :contact


### PR DESCRIPTION
When a Xero Invoice has Prepayments applied to it, the invoices payload will contain something similar to:

```
<Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  ...
  <Invoices>
    <Invoice>
      <Contact>
        ...
      </Contact>
      ...
      <Prepayments>
        <Prepayment>
          <Date>2019-01-17T00:00:00</Date>
          <Total>2000.00</Total>
          <AppliedAmount>500.00</AppliedAmount>
          <PrepaymentID>...</PrepaymentID>
        </Prepayment>
      </Prepayments>
      ...
    </Invoice>
  </Invoices>
</Response>
```

This PR adds the `prepayments` association to the Invoice model, along with the `applied_amount` field so that these can be referenced.