### PR TITLE
Replace BigDecimal.new() with BigDecimal()

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -100,7 +100,7 @@ module Xeroizer
         # Calculate sub_total from line_items.
         def sub_total(always_summary = false)
           if !always_summary && (new_record? || (!new_record? && line_items && line_items.size > 0))
-            overall_sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
+            overall_sum = (line_items || []).inject(BigDecimal('0')) { | sum, line_item | sum + line_item.line_amount }
             
             # If the default amount types are inclusive of 'tax' then remove the tax amount from this sub-total.
             overall_sum -= total_tax if line_amount_types == 'Inclusive' 
@@ -113,7 +113,7 @@ module Xeroizer
         # Calculate total_tax from line_items.
         def total_tax(always_summary = false)
           if !always_summary && (new_record? || (!new_record? && line_items && line_items.size > 0))
-            (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.tax_amount }
+            (line_items || []).inject(BigDecimal('0')) { | sum, line_item | sum + line_item.tax_amount }
           else
             attributes[:total_tax]
           end

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -151,7 +151,7 @@ module Xeroizer
         # Calculate sub_total from line_items.
         def sub_total(always_summary = false)
           if !@sub_total_is_set && not_summary_or_loaded_record(always_summary)
-            overall_sum = (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.line_amount }
+            overall_sum = (line_items || []).inject(BigDecimal('0')) { | sum, line_item | sum + line_item.line_amount }
 
             # If the default amount types are inclusive of 'tax' then remove the tax amount from this sub-total.
             overall_sum -= total_tax if line_amount_types == 'Inclusive'
@@ -164,7 +164,7 @@ module Xeroizer
         # Calculate total_tax from line_items.
         def total_tax(always_summary = false)
           if !@total_tax_is_set && not_summary_or_loaded_record(always_summary)
-            (line_items || []).inject(BigDecimal.new('0')) { | sum, line_item | sum + line_item.tax_amount }
+            (line_items || []).inject(BigDecimal('0')) { | sum, line_item | sum + line_item.tax_amount }
           else
             attributes[:total_tax]
           end

--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -22,7 +22,7 @@ module Xeroizer
                 when :string      then element.text
                 when :boolean     then (element.text == 'true')
                 when :integer     then element.text.to_i
-                when :decimal     then BigDecimal.new(element.text)
+                when :decimal     then BigDecimal(element.text)
                 when :date        then Date.parse(element.text)
                 when :datetime    then Time.parse(element.text)
                 when :datetime_utc then ActiveSupport::TimeZone['UTC'].parse(element.text).utc
@@ -98,7 +98,7 @@ module Xeroizer
               when :decimal   
                 real_value = case value
                   when BigDecimal   then value.to_s
-                  when String       then BigDecimal.new(value).to_s
+                  when String       then BigDecimal(value).to_s
                   else              value
                 end
                 b.tag!(field[:api_name], real_value)

--- a/lib/xeroizer/report/aged_receivables_by_contact.rb
+++ b/lib/xeroizer/report/aged_receivables_by_contact.rb
@@ -31,7 +31,7 @@ module Xeroizer
         end
 
         def sum(column_name, &block)
-          sections.first.rows.inject(BigDecimal.new('0')) do | sum, row |
+          sections.first.rows.inject(BigDecimal('0')) do | sum, row |
             sum += row.cell(column_name).value if row.class == Xeroizer::Report::Row && (block.nil? || block.call(row))
             sum
           end

--- a/lib/xeroizer/report/cell_xml_helper.rb
+++ b/lib/xeroizer/report/cell_xml_helper.rb
@@ -47,7 +47,7 @@ module Xeroizer
 
           def parse_value(value)
             case value
-              when /^[-]?\d+(\.\d+)?$/                      then BigDecimal.new(value)
+              when /^[-]?\d+(\.\d+)?$/                      then BigDecimal(value)
               when /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/  then Time.xmlschema(value)
               else                                          value
             end

--- a/test/unit/models/repeating_invoice_test.rb
+++ b/test/unit/models/repeating_invoice_test.rb
@@ -18,7 +18,7 @@ class RepeatingInvoiceTest < Test::Unit::TestCase
       repeating_invoice = repeating_invoices.first
 
       assert_equal "PowerDirect", repeating_invoice.contact_name
-      assert_equal BigDecimal.new(90), repeating_invoice.total
+      assert_equal BigDecimal(90), repeating_invoice.total
       assert_equal true, repeating_invoice.accounts_payable?
 
       schedule = repeating_invoice.schedule


### PR DESCRIPTION
BigDecimal.new was deprecated in Ruby 2.6

Fixes #471