### PR TITLE
Update comment about nonce being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ If required, the library can handle these exceptions internally by sleeping 1 se
 You can set this option when initializing an application:
 
 ```ruby
-# Sleep for 2 seconds every time the rate limit is exceeded.
+# Sleep for 1 second and retry up to 3 times when Xero claims the nonce was used.
 client = Xeroizer::PublicApplication.new(YOUR_OAUTH_CONSUMER_KEY,
                                          YOUR_OAUTH_CONSUMER_SECRET,
                                          :nonce_used_max_attempts => 3)


### PR DESCRIPTION
Just a quick docs change. This comment was copied from the rate limit retry section.

I'm unfamiliar with the OAuth code, so if this generates a new nonce when retrying, I think that'd be good to clarify. (I assumed the same nonce would be used on subsequent retries.)