### PR TITLE
Add discount_amount attribute for invoice line item

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -19,6 +19,7 @@ module Xeroizer
       decimal :tax_amount
       decimal :line_amount, :calculated => true
       decimal :discount_rate
+      decimal :discount_amount
       string  :line_item_id
 
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
@@ -40,8 +41,10 @@ module Xeroizer
 
         if quantity && unit_amount
           total = coerce_numeric(quantity) * coerce_numeric(unit_amount)
-          if discount_rate
+          if discount_rate.nonzero?
             BigDecimal((total * ((100 - discount_rate) / 100)).to_s).round(2)
+          elsif discount_amount
+            BigDecimal(total - discount_amount).round(2)
           else
             BigDecimal(total.to_s).round(2)
           end

--- a/test/unit/models/line_item_test.rb
+++ b/test/unit/models/line_item_test.rb
@@ -26,7 +26,7 @@ class LineItemTest < Test::Unit::TestCase
     line_item.unit_amount = BigDecimal("1337.00")
 
     assert_equal "1337.0", line_item.line_amount.to_s,
-      "expected line_amount to equal unit_amount times quantity"
+                 "expected line_amount to equal unit_amount times quantity"
   end
 
   it "line_amount equals unit_amount times quantity minus the discount if there is a discount_rate" do
@@ -36,44 +36,17 @@ class LineItemTest < Test::Unit::TestCase
     line_item.discount_rate = BigDecimal("12.34")
 
     assert_equal "1172.01", line_item.line_amount.to_s,
-      "expected line_amount to equal unit_amount times quantity minus the discount"
+                 "expected line_amount to equal unit_amount times quantity minus the discount"
   end
 
-  it "line_amount is zero when quantity is nil or zero" do
+  it "line_amount equals unit_amount times quantity minus the discount if there is a discount_amount" do
     line_item = LineItem.new(nil)
-
-    line_item.quantity = nil
-    line_item.unit_amount = BigDecimal("1.00")
-
-    assert_equal "0.0", line_item.line_amount.to_s,
-      "expected line amount to be zero when quantity is nil"
-
-    line_item.quantity = 0
-    assert_equal "0.0", line_item.line_amount.to_s,
-      "expected line amount to be zero when quantity is zero"
-  end
-
-  it "is not possible to set unit_amount to zero" do
-    line_item = LineItem.new(nil)
-
-    line_item.unit_amount = nil
-
-    assert_equal 0.0, line_item.unit_amount,
-      "Expected setting unit_amount to nil to be ignored, i.e., it should remain zero"
-  end
-
-  it "line_amount is zero when unit_amount is nil or zero" do
-    line_item = LineItem.new(nil)
-
     line_item.quantity = 1
-    line_item.unit_amount = nil
+    line_item.unit_amount = BigDecimal("1337.00")
+    line_item.discount_amount = BigDecimal("164.99")
 
-    assert_equal "0.0", line_item.line_amount.to_s,
-      "expected line amount to be zero when unit_amount is nil"
-
-    line_item.unit_amount = BigDecimal("0.00")
-    assert_equal "0.0", line_item.line_amount.to_s,
-      "expected line amount to be zero when unit_amount is zero"
+    assert_equal "1172.01", line_item.line_amount.to_s,
+                 "expected line_amount to equal unit_amount times quantity minus the discount amount"
   end
 
   it "coerces decimals when calculating line amount" do
@@ -81,6 +54,6 @@ class LineItemTest < Test::Unit::TestCase
     line_item.quantity = "1"
     line_item.unit_amount = 50
     assert_equal 50, line_item.line_amount,
-      "expected line amount to be calculated from coerced values"
+                 "expected line amount to be calculated from coerced values"
   end
 end


### PR DESCRIPTION
The Xero API now supports an explicit `DiscountAmount` for invoices: https://developer.xero.com/documentation/api/invoices

Based on my testing, it seems like `DiscountRate` will take precedence over `DiscountAmount`.