### PR TITLE
Update cell parser regex

### DIFF
--- a/lib/xeroizer/report/cell_xml_helper.rb
+++ b/lib/xeroizer/report/cell_xml_helper.rb
@@ -1,19 +1,19 @@
 module Xeroizer
   module Report
     module CellXmlHelper
-    
+
       def self.included(base)
         base.extend(ClassMethods)
         base.send :include, InstanceMethods
       end
-    
+
       module ClassMethods
-      
+
         public
-      
+
           # Create an instance of Cell from the node.
           #
-          # Additionally, parse the attributes and return them as a hash to the 
+          # Additionally, parse the attributes and return them as a hash to the
           # cell. If a cell's attributes look like:
           #
           #     <Attributes>
@@ -22,7 +22,7 @@ module Xeroizer
           #         <Id>account</Id>
           #       </Attribute>
           #     </Attributes>
-          # 
+          #
           # Return a hash like:
           #
           #     {
@@ -42,17 +42,17 @@ module Xeroizer
             end
             cell
           end
-          
+
         protected
 
           def parse_value(value)
             case value
-              when /^[-]?\d+(\.\d+)?$/                      then BigDecimal(value)
-              when /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/  then Time.xmlschema(value)
-              else                                          value
+              when /\A[-]?\d+(\.\d+)?\z/                      then BigDecimal(value)
+              when /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\z/  then Time.xmlschema(value)
+              else                                            value
             end
           end
-        
+
           def parse_attribute(attribute_node)
             id = nil
             value = nil
@@ -65,10 +65,10 @@ module Xeroizer
             [id, value]
           end
       end
-    
+
       module InstanceMethods
       end
-    
+
     end
   end
 end


### PR DESCRIPTION
^ and $ will only match up until a newline character, prefer \A and \z. This was causing an issue when parsing a Xero bank statement report which contained multi-line data and was incorrectly parsed as a BigDecimal.
For more info:
https://stackoverflow.com/questions/577653/difference-between-a-z-and-in-ruby-regular-expressions