### PR TITLE
Make sure we can convert to BigDecimal with discount_amount

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -44,7 +44,7 @@ module Xeroizer
           if discount_rate.nonzero?
             BigDecimal((total * ((100 - discount_rate) / 100)).to_s).round(2)
           elsif discount_amount
-            BigDecimal(total - discount_amount).round(2)
+            BigDecimal((total - discount_amount).to_s).round(2)
           else
             BigDecimal(total.to_s).round(2)
           end


### PR DESCRIPTION
Error introduced with https://github.com/waynerobinson/xeroizer/pull/483. We need to convert the calculated value into a string as we can't convert a float without a precision.