### PR TITLE
Document how to provide a private key directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ client = Xeroizer::PrivateApplication.new(YOUR_OAUTH_CONSUMER_KEY, YOUR_OAUTH_CO
 contacts = client.Contact.all
 ```
 
+To provide a private key directly, set the path to nil and pass in a `private_key` option instead. For example:
+
+```ruby
+# Using environment variables (e.g. Heroku):
+client = Xeroizer::PrivateApplication.new(key, secret, nil, private_key: ENV["XERO_PRIVATE_KEY"])
+
+# Using Rails Credentials (Rails 5.2+):
+client = Xeroizer::PrivateApplication.new(key, secret, nil, private_key: Rails.application.credentials.xero_private_key)
+```
+
 ### Partner Applications
 
 Partner applications use a combination of 3-legged authorisation and private key message signing.


### PR DESCRIPTION
https://github.com/waynerobinson/xeroizer/issues/338 was closed without being implemented. https://github.com/waynerobinson/xeroizer/issues/80 previously provided a workaround to the same underlying problem/question.

This documentation change explains how to provide a private key directly (rather than a file path) and provides examples for two common scenarios; using environment variables or Rails Credentials.

N.B. The very next section on `PartnerApplication`s also talks about private key paths. I considered adding a "nod" back to this section from there but didn't want to distract from the main point. Might be helpful for those who aren't reading the README sequentially though.