### PR TITLE
Fix float to BigDecimal Conversion ArgumentError in line_item

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -44,7 +44,7 @@ module Xeroizer
           if discount_rate.nonzero?
             BigDecimal((total * ((100 - discount_rate) / 100)).to_s).round(2)
           elsif discount_amount
-            BigDecimal(total - discount_amount).round(2)
+            BigDecimal((total - discount_amount).to_s).round(2)
           else
             BigDecimal(total.to_s).round(2)
           end


### PR DESCRIPTION
I hit the following error: 
```/usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/line_item.rb:47:in `BigDecimal': can't omit precision for a Float. (ArgumentError)
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/line_item.rb:47:in `line_amount'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/invoice.rb:155:in `block in sub_total'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/invoice.rb:155:in `each'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/invoice.rb:155:in `inject'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/invoice.rb:155:in `sub_total'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/models/invoice.rb:177:in `total'
	from xero_export_invoice_items.rb:64:in `block (3 levels) in <main>'
	from xero_export_invoice_items.rb:44:in `each'
	from xero_export_invoice_items.rb:44:in `block (2 levels) in <main>'
	from xero_export_invoice_items.rb:41:in `each'
	from xero_export_invoice_items.rb:41:in `block in <main>'
	from /usr/local/bundle/bundler/gems/xeroizer-8af288118359/lib/xeroizer/record/base_model.rb:133:in `find_in_batches'
	from xero_export_invoice_items.rb:38:in `<main>'```

The fix is a single liner.