### PR TITLE
Remove duplicate method

### DIFF
--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -116,7 +116,7 @@ module Xeroizer
         build(attributes).tap { |resource| resource.save }
       end
 
-      # Retreive full record list for this model.
+      # Retrieve full record list for this model.
       def all(options = {})
         raise MethodNotAllowed.new(self, :all) unless self.class.permissions[:read]
         response_xml = http_get(parse_params(options))

--- a/lib/xeroizer/record/base_model.rb
+++ b/lib/xeroizer/record/base_model.rb
@@ -209,10 +209,6 @@ module Xeroizer
         :http_put
       end
 
-        def create_method
-          :http_put
-        end
-
       protected
 
 


### PR DESCRIPTION
Remove duplicate method inside `lib/xeroizer/record/base_model.rb` and fix small typo. It seems like a result of bad merge here: https://github.com/waynerobinson/xeroizer/commit/eefa1128dfb59e8bdf0c2945f6373e45748b7a89#diff-93206deb435bfc382e3aac1275dc7d36