### PR TITLE
Fix incorrect reference in HTTP Response error message

### DIFF
--- a/lib/xeroizer/http_response.rb
+++ b/lib/xeroizer/http_response.rb
@@ -118,7 +118,7 @@ module Xeroizer
     def raise_error!
       begin
         error_details = JSON.parse(response.plain_body)
-        description  = error_details["detail"]
+        description  = error_details["Detail"]
         case response.code.to_i
         when 400
           raise Xeroizer::BadResponse.new(description)


### PR DESCRIPTION
A minor fix to change the error message key. When the error was raised in my test, the following was the response:

`
{"Type"=>nil,
 "Title"=>"Unauthorized",
 "Status"=>401,
 "Detail"=>"TokenExpired: token expired at 03/03/2020 09:46:07",
 "Instance"=>"[instance-id]",
 "Extensions"=>{}}
`