### PR TITLE
Added support for 429 Too Many Requests, which Xero now sends

### DIFF
--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -170,6 +170,32 @@ class HttpTest < UnitTestCase
       end
     end
 
+    context "429" do
+      setup do
+        @status_code = 429
+      end
+
+      context "rate_limit_exceeded" do
+        setup do
+          stub_request(:get, @uri).to_return(
+            status: @status_code,
+            body: "",
+            headers: {
+              "x-daylimit-remaining" => "328",
+              "retry-after" => "42",
+            }
+          )
+        end
+
+        should "raise an OAuth::RateLimitExceeded" do
+          error = assert_raises(Xeroizer::OAuth::RateLimitExceeded){ @application.http_get(@application.client, @uri) }
+          assert_match /rate limit exceeded/i, error.message
+          assert_match /328 requests left for the day/i, error.message
+          assert_match /42 seconds until you can make another request/i, error.message
+        end
+      end
+    end
+
     context "503" do
       setup do
         @status_code = 503


### PR DESCRIPTION
I just discovered that Xero returns a 429 Too Many Requests for the rate limit case, when using OAuth2. This PR adds the necessary support for it.

*NOTE:* I couldn't run the tests, because I couldn't register an OAuth1 app. I will rework the tests if someone else runs the tests and they fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waynerobinson/xeroizer/510)
<!-- Reviewable:end -->
