### PR TITLE
Record Options - add status key.

### DIFF
--- a/lib/xeroizer/models/option.rb
+++ b/lib/xeroizer/models/option.rb
@@ -11,7 +11,7 @@ module Xeroizer
       
       guid   :tracking_option_id
       string :name
-      
+      string :status
     end
     
   end


### PR DESCRIPTION
Documentation says `status` is allowed for record options: https://developer.xero.com/documentation/api/tracking-categories#Options