### PR TITLE
Conditionally validate line item description

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -24,7 +24,7 @@ module Xeroizer
 
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
 
-      validates_presence_of :description
+      validates_presence_of :description, :unless => Proc.new { |line_item| line_item.item_code.present? }
 
       def initialize(parent)
         super(parent)


### PR DESCRIPTION
After changes introduced in #517 Xeroizer can't create an invoice with 
line items having only `quantity` and `item_code` set, as validation will fail 
with "Line items must all be valid" error.

Since Xero API will accept line items without `description` in this case, 
this conditionally requires `description` to be present only when `item_code` is not. 