### PR TITLE
Revert "We don't use sent_to_contact"

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -64,6 +64,7 @@ module Xeroizer
       string        :currency_code
       decimal       :currency_rate
       datetime      :fully_paid_on_date
+      boolean       :sent_to_contact
       decimal       :remaining_credit
       decimal       :applied_amount
       boolean       :has_attachments

--- a/lib/xeroizer/models/invoice.rb
+++ b/lib/xeroizer/models/invoice.rb
@@ -82,6 +82,7 @@ module Xeroizer
       datetime     :fully_paid_on_date
       datetime     :expected_payment_date
       datetime     :planned_payment_date
+      boolean      :sent_to_contact
       boolean      :has_attachments
 
       belongs_to   :contact


### PR DESCRIPTION
This reverts commit a4a82dcf20af623f7d19809c9c703e349caeab26.

Resolves: https://github.com/waynerobinson/xeroizer/issues/516