### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,7 @@ client = Xeroizer::OAuth2Application.new(
 	YOUR_OAUTH2_CLIENT_ID,
 	YOUR_OAUTH2_CLIENT_SECRET,
 	access_token: access_token,
-	refresh_token: refresh_token,
-	tenant_id: tenant_id
+	refresh_token: refresh_token
 )
 
 client.renew_access_token


### PR DESCRIPTION
When renewing an OAuth2 access token, the `tenant_id` is not strictly required. Tokens are issued on a per-user basis and can be independently updated as required.