### PR TITLE
Avoid extra API call when accessing allocations from credit note

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -71,7 +71,7 @@ module Xeroizer
 
       belongs_to    :contact
       has_many      :line_items
-      has_many      :allocations
+      has_many      :allocations, :list_complete => true
 
       validates_inclusion_of :type, :in => CREDIT_NOTE_TYPES
       validates_inclusion_of :status, :in => CREDIT_NOTE_STATUSES, :allow_blanks => true


### PR DESCRIPTION
When looping through credit notes records, we noticed that we're being rate limited especially when there are many of credit notes.
Upon checking, it seems an API call is made whenever we call `.total` `.sub_total` , `.total_tax` and  `.allocations` from credit note (for the first time)

For `.total`, `.sub_total` and `.tax_total`, we're able to avoid extra API call by enabling `always_summary` (e.g. `credit_note_response.total([true])`)

This PR aims to fix the issue for `.allocations`