### PR TITLE
Update line_item.rb

### DIFF
--- a/lib/xeroizer/models/line_item.rb
+++ b/lib/xeroizer/models/line_item.rb
@@ -20,7 +20,7 @@ module Xeroizer
       decimal :line_amount, :calculated => true
       decimal :discount_rate
       decimal :discount_amount
-      string  :line_item_id
+      guid  :line_item_id
 
       has_many  :tracking, :model_name => 'TrackingCategoryChild'
 


### PR DESCRIPTION
Changing line_item_id to be a guid not a string - this is necessary to produce LineItemID rather than LineItemId in the XML - Xero's parsing is case-sensitive.