### PR TITLE
Add edition to organisation.rb

### DIFF
--- a/lib/xeroizer/models/organisation.rb
+++ b/lib/xeroizer/models/organisation.rb
@@ -59,6 +59,7 @@ module Xeroizer
       datetime_utc  :created_date_utc, :api_name => 'CreatedDateUTC'
       string    :sales_tax_basis
       string    :sales_tax_period
+      string    :edition
 
       has_many :addresses
       has_many :phones


### PR DESCRIPTION
`edition` as a field is defined here.
https://developer.xero.com/documentation/api/accounting/organisation

However it is not supported yet. 

This PR aims to add support for this field.

Thanks