### PR TITLE
Add missing BatchPaymentID field to Payment model

### DIFF
--- a/lib/xeroizer/models/payment.rb
+++ b/lib/xeroizer/models/payment.rb
@@ -21,6 +21,7 @@ module Xeroizer
       string        :reference
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
       boolean       :is_reconciled
+      string        :batch_payment_id
 
       belongs_to    :account
       belongs_to    :invoice


### PR DESCRIPTION
Changes
- Added string :batch_payment_id to Payment model attributes

Testing
- Verified the change works by retrieving a payment that's part of a batch payment from Xero - the batch_payment_id field is properly populated.

API Reference
https://developer.xero.com/documentation/api/accounting/payments