### PR TITLE
Unify attribute lookup in build and attributes= methods

### DIFF
--- a/lib/xeroizer/record/base.rb
+++ b/lib/xeroizer/record/base.rb
@@ -30,8 +30,7 @@ module Xeroizer
         def build(attributes, parent)
           record = new(parent)
           attributes.each do | key, value |
-            attr = record.respond_to?("#{key}=") || record.class.fields[key].nil? ? key : record.class.fields[key][:internal_name]
-            record.send("#{attr}=", value)
+            record.send("#{record.resolve_attribute_key(key)}=", value)
           end
           record
         end
@@ -67,9 +66,13 @@ module Xeroizer
           return unless new_attributes.is_a?(Hash)
           parent.mark_dirty(self) if parent
           new_attributes.each do | key, value |
-            attr = respond_to?("#{key}=") ? key : self.class.fields[key][:internal_name]
-            self.send("#{attr}=", value)
+            self.send("#{resolve_attribute_key(key)}=", value)
           end
+        end
+
+        def resolve_attribute_key(key)
+          field = self.class.fields[key]
+          respond_to?("#{key}=") || field.nil? ? key : field[:internal_name]
         end
 
         def update_attributes(attributes)

--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -108,9 +108,23 @@ class RecordBaseTest < Test::Unit::TestCase
   context 'build' do
 
     should "raise an undefined method error with useful message" do
-      assert_raise_message("undefined method `this_method_does_not_exist=' for #<Xeroizer::Record::Contact >") do
+      error = assert_raises(NoMethodError) do
         @client.Contact.build(:this_method_does_not_exist =>  true)
       end
+      assert_match /undefined method .this_method_does_not_exist=./, error.message
+      assert_match /Xeroizer::Record::Contact/, error.message
+    end
+
+  end
+
+  context 'attributes=' do
+
+    should "raise an undefined method error with useful message" do
+      error = assert_raises(NoMethodError) do
+        @contact.attributes = {:this_method_does_not_exist => true}
+      end
+      assert_match /undefined method .this_method_does_not_exist=./, error.message
+      assert_match /Xeroizer::Record::Contact/, error.message
     end
 
   end


### PR DESCRIPTION
## Summary
- Extracts `resolve_attribute_key` as a shared method used by both `.build` and `#attributes=`
- `#attributes=` now raises a clear `NoMethodError` for invalid attribute names, matching the behavior added to `.build` in #419
- Previously `#attributes=` would raise an unhelpful `NoMethodError: undefined method '[]' for nil` when given an invalid key

Fixes #436

## Test plan
- [x] New test: `attributes=` with invalid key raises `NoMethodError` with the attribute name
- [x] Updated existing `build` test to use regex matching (works across Ruby versions)
- [x] All tests in `base_test.rb` pass (except 4 pre-existing failures unrelated to this change)