### PR TITLE
Make rate_limit_sleep work under raise_errors: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+> These changes have been merged but not yet released, so the version they will
+> ship in is not yet decided. Note that this section contains a **breaking
+> change** (see below); under SemVer that implies the next release will be a new
+> major version.
+
+### Breaking
+
+- 429 responses now raise `Xeroizer::OAuth::RateLimitExceeded` instead of the
+  raw `OAuth2::Error` for consumers running the OAuth2 client with
+  `raise_errors: true`. Update any rescue chains accordingly.
+  Non-429 `OAuth2::Error`s are unaffected and still propagate unchanged.
+
+### Added
+
+- `company_number` attribute on Contact. (#559)
+- `edition` attribute on Organisation. (#564)
+- `batch_payment_id` attribute on Payment. (#568)
+
+### Changed
+
+- `LineItem#line_item_id` is now a guid, producing `LineItemID` in XML to match Xero's case-sensitive parsing. (#562)
+- `rate_limit_sleep: true` now respects the `Retry-After` response header. (#569)
+- `rate_limit_sleep` now also works under `raise_errors: true`.
+- A numeric `rate_limit_sleep` is now clamped to a non-negative number.
+  Fractional values are preserved (`2.5` sleeps 2.5 seconds). Negative values
+  sleep 0 seconds rather than raising.
+- Under `raise_errors: true`, the `before_request`/`after_request` and response
+  logging hooks now fire for 429 responses (they previously could not, because
+  the `oauth2` gem raised before xeroizer's response layer ran). This keeps
+  observability consistent across both `raise_errors` modes.
+
+### Fixed
+
+- `#attributes=` now raises the same clear `undefined method` error as `.build` when given an invalid attribute name. (#570)
+- Avoid an extra API call when accessing allocations from a credit note. (#554)
+- A `raw_body: true` request body is now computed once before the retry loop, so
+  a retried request re-sends the same raw body instead of falling back to the
+  `xml=`-wrapped form, and `:raw_body` is no longer serialized into the request
+  query string.
+
+## 3.0.1
+
+See the Git history for changes up to and including 3.0.1.

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -81,6 +81,11 @@ module Xeroizer
         end
       end
 
+      # Compute the request body once, before the retry loop, so retries
+      # send the same body on every attempt. Also done before URL building
+      # so :raw_body isn't serialized into the query string.
+      raw_body = params.delete(:raw_body) ? request_body : {:xml => request_body}
+
       if params.any?
         url += "?" + params.map {|key, value| "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"}.join("&")
       end
@@ -95,8 +100,6 @@ module Xeroizer
       begin
         attempts += 1
         logger.info("XeroGateway Request: #{method.to_s.upcase} #{uri.request_uri}") if self.logger
-
-        raw_body = params.delete(:raw_body) ? request_body : {:xml => request_body}
 
         response = with_around_request(request_info) do
           case method
@@ -116,19 +119,43 @@ module Xeroizer
         sleep_for(1)
         retry
       rescue Xeroizer::OAuth::RateLimitExceeded => exception
-        if self.rate_limit_sleep
-          raise if attempts > rate_limit_max_attempts
-          sleep_duration = if self.rate_limit_sleep == true
-                            (exception.retry_after && exception.retry_after > 0) ? exception.retry_after : 1
-                          else
-                            self.rate_limit_sleep
-                          end
-          logger.info("Rate limit exceeded, retrying in #{sleep_duration}s") if self.logger
-          sleep_for(sleep_duration)
-          retry
-        else
-          raise
-        end
+        sleep_duration = rate_limit_sleep_duration!(exception, attempts)
+        logger.warn(
+          "Rate limit exceeded (attempt #{attempts}/#{rate_limit_max_attempts}, " \
+          "retry_after=#{exception.retry_after}s, " \
+          "daily_remaining=#{exception.daily_limit_remaining}); " \
+          "sleeping #{sleep_duration}s before retry"
+        ) if self.logger
+        sleep_for(sleep_duration)
+        retry
+      rescue ::OAuth2::Error => exception
+        # When raise_errors: true is set on the OAuth2 client, the oauth2 gem
+        # raises OAuth2::Error for any non-2xx response before xeroizer's
+        # HttpResponse layer can inspect it. This means 429 responses never
+        # reach the normal RateLimitExceeded path above.
+        #
+        # This rescue intercepts those raw OAuth2::Error exceptions, converts
+        # 429s to RateLimitExceeded, and feeds them through the same retry
+        # logic so rate_limit_sleep works regardless of raise_errors setting.
+        raise unless exception.response && exception.response.status == 429
+
+        # Run the same observability hooks the raise_errors:false path runs,
+        # so log_response/after_request fire for both modes symmetrically.
+        wrapped_response = Xeroizer::OAuth2::Response.new(exception.response)
+        log_response(wrapped_response, uri)
+        after_request.call(request_info, wrapped_response) if after_request
+
+        rate_limit_exception = Xeroizer::OAuth::RateLimitExceeded.from_headers(exception.response.headers)
+        sleep_duration = rate_limit_sleep_duration!(rate_limit_exception, attempts)
+        logger.warn(
+          "Rate limit exceeded (intercepted OAuth2::Error, " \
+          "attempt #{attempts}/#{rate_limit_max_attempts}, " \
+          "retry_after=#{rate_limit_exception.retry_after}s, " \
+          "daily_remaining=#{rate_limit_exception.daily_limit_remaining}); " \
+          "sleeping #{sleep_duration}s before retry"
+        ) if self.logger
+        sleep_for(sleep_duration)
+        retry
       end
     end
 
@@ -151,6 +178,17 @@ module Xeroizer
 
     def sleep_for(seconds = 1)
       sleep seconds
+    end
+
+    def rate_limit_sleep_duration!(exception, attempts)
+      raise exception unless self.rate_limit_sleep
+      raise exception if attempts > rate_limit_max_attempts
+
+      if self.rate_limit_sleep == true
+        (exception.retry_after && exception.retry_after > 0) ? exception.retry_after : 1
+      else
+        [self.rate_limit_sleep.to_f, 0].max
+      end
     end
 
     # unitdp query string parameter to be added to request params

--- a/lib/xeroizer/http_response.rb
+++ b/lib/xeroizer/http_response.rb
@@ -93,11 +93,7 @@ module Xeroizer
     end
 
     def raise_rate_limit_exceeded!
-      retry_after = response.response.headers["retry-after"].to_i
-      daily_limit_remaining = response.response.headers["x-daylimit-remaining"].to_i
-
-      description = "Rate limit exceeded: #{daily_limit_remaining} requests left for the day, #{retry_after} seconds until you can make another request"
-      raise OAuth::RateLimitExceeded.new(description, retry_after: retry_after, daily_limit_remaining: daily_limit_remaining)
+      raise OAuth::RateLimitExceeded.from_headers(response.response.headers)
     end
 
     def raise_unknown_response_error!

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -33,6 +33,14 @@ module Xeroizer
     class UnknownError < OAuthError; end
 
     class RateLimitExceeded < OAuthError
+      # @api private
+      def self.from_headers(headers)
+        retry_after = (headers['retry-after'] || 0).to_i
+        daily_limit_remaining = (headers['x-daylimit-remaining'] || 0).to_i
+        description = "Rate limit exceeded: #{daily_limit_remaining} requests left for the day, #{retry_after} seconds until you can make another request"
+        new(description, retry_after: retry_after, daily_limit_remaining: daily_limit_remaining)
+      end
+
       def initialize(description, retry_after: nil, daily_limit_remaining: nil)
         super(description)
 

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -184,77 +184,330 @@ class HttpTest < UnitTestCase
           assert_equal 328, error.daily_limit_remaining
         end
       end
-    end
 
-    context "rate_limit_sleep with retry-after" do
-      setup do
-        @retry_after_seconds = 42
-        stub_request(:get, @uri).to_return(
-          status: 429,
-          body: "",
-          headers: {
-            "x-daylimit-remaining" => "328",
-            "retry-after" => @retry_after_seconds.to_s,
-          }
-        ).then.to_return(status: 200, body: "<Response/>")
-      end
+      context "rate_limit_sleep" do
+        context "raise_errors: false" do
+          setup do
+            @retry_after_seconds = 42
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "x-daylimit-remaining" => "328",
+                "retry-after" => @retry_after_seconds.to_s,
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+          end
 
-      context "when rate_limit_sleep is true" do
-        setup do
-          @application = Xeroizer::OAuth2Application.new(
-            CLIENT_ID, CLIENT_SECRET,
-            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
-            rate_limit_sleep: true
-          )
+          context "when rate_limit_sleep is true" do
+            setup do
+              @application = Xeroizer::OAuth2Application.new(
+                CLIENT_ID, CLIENT_SECRET,
+                tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+                rate_limit_sleep: true
+              )
+            end
+
+            should "sleep for the retry-after duration from the response and return the retried response body" do
+              @application.expects(:sleep_for).with(@retry_after_seconds)
+              result = @application.http_get(@application.client, @uri)
+              assert_equal "<Response/>", result
+            end
+          end
+
+          context "when rate_limit_sleep is a number" do
+            setup do
+              @application = Xeroizer::OAuth2Application.new(
+                CLIENT_ID, CLIENT_SECRET,
+                tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+                rate_limit_sleep: 5
+              )
+            end
+
+            should "sleep for the configured number of seconds and return the retried response body" do
+              @application.expects(:sleep_for).with(5)
+              result = @application.http_get(@application.client, @uri)
+              assert_equal "<Response/>", result
+            end
+          end
+
+          context "when rate_limit_sleep is a float" do
+            setup do
+              @application = Xeroizer::OAuth2Application.new(
+                CLIENT_ID, CLIENT_SECRET,
+                tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+                rate_limit_sleep: 2.5
+              )
+            end
+
+            should "sleep for the fractional number of seconds (preserves float precision)" do
+              @application.expects(:sleep_for).with(2.5)
+              result = @application.http_get(@application.client, @uri)
+              assert_equal "<Response/>", result
+            end
+          end
+
+          context "when rate_limit_sleep is true but retry-after is missing" do
+            setup do
+              WebMock.reset!
+              stub_request(:get, @uri).to_return(
+                status: 429,
+                body: "",
+                headers: {}
+              ).then.to_return(status: 200, body: "<Response/>")
+              @application = Xeroizer::OAuth2Application.new(
+                CLIENT_ID, CLIENT_SECRET,
+                tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+                rate_limit_sleep: true
+              )
+            end
+
+            should "fall back to sleeping for 1 second and return the retried response body" do
+              @application.expects(:sleep_for).with(1)
+              result = @application.http_get(@application.client, @uri)
+              assert_equal "<Response/>", result
+            end
+          end
+
+          context "when rate_limit_sleep is false" do
+            should "raise without retrying" do
+              assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
+                @application.http_get(@application.client, @uri)
+              }
+            end
+          end
         end
 
-        should "sleep for the retry-after duration from the response" do
-          @application.expects(:sleep_for).with(@retry_after_seconds)
-          @application.http_get(@application.client, @uri)
-        end
-      end
+        context "raise_errors: true" do
+          setup do
+            @retry_after_seconds = 42
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: true,
+              raise_errors: true
+            )
+          end
 
-      context "when rate_limit_sleep is a number" do
-        setup do
-          @application = Xeroizer::OAuth2Application.new(
-            CLIENT_ID, CLIENT_SECRET,
-            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
-            rate_limit_sleep: 5
-          )
-        end
+          should "catch OAuth2::Error on 429, retry with sleep, and return the retried response body" do
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => @retry_after_seconds.to_s,
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
 
-        should "sleep for the configured number of seconds" do
-          @application.expects(:sleep_for).with(5)
-          @application.http_get(@application.client, @uri)
-        end
-      end
+            @application.expects(:sleep_for).with(@retry_after_seconds)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+          end
 
-      context "when rate_limit_sleep is true but retry-after is missing" do
-        setup do
-          WebMock.reset!
-          stub_request(:get, @uri).to_return(
-            status: 429,
-            body: "",
-            headers: {}
-          ).then.to_return(status: 200, body: "<Response/>")
-          @application = Xeroizer::OAuth2Application.new(
-            CLIENT_ID, CLIENT_SECRET,
-            tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
-            rate_limit_sleep: true
-          )
-        end
+          context "when rate_limit_sleep is a number" do
+            setup do
+              @application = Xeroizer::OAuth2Application.new(
+                CLIENT_ID, CLIENT_SECRET,
+                tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+                rate_limit_sleep: 5,
+                raise_errors: true
+              )
+            end
 
-        should "fall back to sleeping for 1 second" do
-          @application.expects(:sleep_for).with(1)
-          @application.http_get(@application.client, @uri)
-        end
-      end
+            should "sleep for the configured number of seconds and return the retried response body" do
+              stub_request(:get, @uri).to_return(
+                status: 429,
+                body: "",
+                headers: {
+                  "retry-after" => "42",
+                  "x-daylimit-remaining" => "328",
+                }
+              ).then.to_return(status: 200, body: "<Response/>")
 
-      context "when rate_limit_sleep is false" do
-        should "raise without retrying" do
-          assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
-            @application.http_get(@application.client, @uri)
-          }
+              @application.expects(:sleep_for).with(5)
+              result = @application.http_get(@application.client, @uri)
+              assert_equal "<Response/>", result
+            end
+          end
+
+          should "fall back to sleeping for 1 second when retry-after is missing" do
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {}
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(1)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+          end
+
+          should "raise RateLimitExceeded after rate_limit_max_attempts is exceeded" do
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: true,
+              rate_limit_max_attempts: 1,
+              raise_errors: true
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "42",
+                "x-daylimit-remaining" => "328",
+              }
+            )
+
+            @application.expects(:sleep_for).with(42).once
+
+            error = assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
+              @application.http_get(@application.client, @uri)
+            }
+            assert_equal 42, error.retry_after
+            assert_equal 328, error.daily_limit_remaining
+          end
+
+          should "raise RateLimitExceeded (not OAuth2::Error) when rate_limit_sleep is false" do
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: false,
+              raise_errors: true
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "42",
+                "x-daylimit-remaining" => "328",
+              }
+            )
+
+            error = assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
+              @application.http_get(@application.client, @uri)
+            }
+            assert_equal 42, error.retry_after
+            assert_equal 328, error.daily_limit_remaining
+          end
+
+          should "re-raise OAuth2::Error for non-429 statuses" do
+            stub_request(:get, @uri).to_return(
+              status: 500,
+              body: "Server Error",
+              headers: {}
+            )
+
+            assert_raises(OAuth2::Error) {
+              @application.http_get(@application.client, @uri)
+            }
+          end
+
+          should "re-raise OAuth2::Error when the underlying response is nil (defensive guard)" do
+            # Defensive case: construct an OAuth2::Error whose response is nil.
+            # The oauth2 gem itself always wraps a response in practice, but the
+            # rescue's `exception.response &&` short-circuit must handle it
+            # without raising NoMethodError on `.status`.
+            nil_response_error = ::OAuth2::Error.new({})
+            nil_response_error.instance_variable_set(:@response, nil)
+
+            @application.expects(:with_around_request).raises(nil_response_error)
+
+            assert_raises(::OAuth2::Error) {
+              @application.http_get(@application.client, @uri)
+            }
+          end
+
+          should "retry POST with the same request body on 429" do
+            request_body = "<Payment><Amount>100.00</Amount></Payment>"
+            stub_request(:post, @uri).with(body: hash_including(xml: request_body)).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "1",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(1)
+            result = @application.http_post(@application.client, @uri, request_body)
+            assert_equal "<Response/>", result
+            assert_requested(:post, @uri, body: hash_including(xml: request_body), times: 2)
+          end
+
+          should "retry PUT with the same request body on 429" do
+            request_body = "<Payment><Amount>100.00</Amount></Payment>"
+            stub_request(:put, @uri).with(body: hash_including(xml: request_body)).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "1",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(1)
+            result = @application.http_put(@application.client, @uri, request_body)
+            assert_equal "<Response/>", result
+            assert_requested(:put, @uri, body: hash_including(xml: request_body), times: 2)
+          end
+
+          should "not serialize raw_body=true into POST URL" do
+            stub_request(:post, @uri).to_return(status: 200, body: "<Response/>")
+            @application.http_post(@application.client, @uri, "raw payload", raw_body: true)
+            assert_requested(:post, @uri) { |req| !req.uri.to_s.include?("raw_body") }
+          end
+
+          should "re-send a raw_body request as a raw body (not xml-wrapped) across a 429 retry" do
+            raw = "raw payload"
+            # Both the initial 429 and the retry must match the *raw* body. If the
+            # raw_body computation regressed back inside the retry loop, the retry
+            # would resend {:xml => ...} ("xml=raw+payload") instead, miss this
+            # stub, and WebMock would raise on the unstubbed request.
+            stub_request(:post, @uri).with(body: raw).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "1",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(1)
+            result = @application.http_post(@application.client, @uri, raw, raw_body: true)
+            assert_equal "<Response/>", result
+            assert_requested(:post, @uri, body: raw, times: 2)
+            assert_requested(:post, @uri, times: 2) { |req| !req.uri.to_s.include?("raw_body") }
+          end
+
+          should "invoke after_request hook for 429 responses (observability symmetry)" do
+            after_request_calls = []
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: true,
+              raise_errors: true,
+              after_request: proc { |request_info, response| after_request_calls << [request_info, response] }
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "1",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(1)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+            assert_equal 2, after_request_calls.length
+            assert_equal 429, after_request_calls.first.last.code
+            assert_equal 200, after_request_calls.last.last.code
+          end
         end
       end
     end


### PR DESCRIPTION
When the underlying OAuth2 client is configured with raise_errors: true, the oauth2 gem raises OAuth2::Error for any non-2xx response before xeroizer's HttpResponse layer can convert 429s to RateLimitExceeded. This made rate_limit_sleep dead code for raise_errors: true consumers: a 429 surfaced as a raw OAuth2::Error instead of being slept-and-retried.

Breaking change for raise_errors: true consumers: 429 responses on API requests now raise Xeroizer::OAuth::RateLimitExceeded instead of OAuth2::Error.

I tested this against the live API to confirm everything is working as intended.

I also added a changelog and populated it with all changes since the last release.