### PR TITLE
Build BrandingTheme#add_payment_service body with Builder instead of Hash#to_xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a retried request re-sends the same raw body instead of falling back to the
   `xml=`-wrapped form, and `:raw_body` is no longer serialized into the request
   query string.
+- `BrandingTheme#add_payment_service` now builds its request body with `Builder`
+  instead of ActiveSupport's `Hash#to_xml`, removing a hidden dependency on an
+  ActiveSupport extension the gem never required.
+- `lib/xeroizer` now requires `json` explicitly rather than relying on it being
+  loaded transitively by another gem.
 
 ## 3.0.1
 

--- a/lib/xeroizer.rb
+++ b/lib/xeroizer.rb
@@ -10,6 +10,7 @@ require 'builder'
 require 'time'
 require 'bigdecimal'
 require 'cgi'
+require 'json'
 
 $: << File.expand_path(File.dirname(__FILE__))
 

--- a/lib/xeroizer/models/branding_theme.rb
+++ b/lib/xeroizer/models/branding_theme.rb
@@ -14,11 +14,10 @@ module Xeroizer
       end
 
       def add_payment_service(id:, payment_service_id:)
-        xml = {
-          PaymentService: {
-            PaymentServiceID: payment_service_id
-          }
-        }.to_xml
+        b = Builder::XmlMarkup.new(:indent => 2)
+        xml = b.tag!('PaymentService') do
+          b.tag!('PaymentServiceID', payment_service_id)
+        end
 
         @application.http_post(@application.client, payment_services_endpoint(id), xml)
       end

--- a/test/unit/models/branding_theme_test.rb
+++ b/test/unit/models/branding_theme_test.rb
@@ -1,0 +1,54 @@
+require 'unit_test_helper'
+
+# BrandingTheme#add_payment_service POSTs a small PaymentService body to Xero.
+class BrandingThemeTest < UnitTestCase
+  include TestHelper
+
+  OK_RESPONSE = "<Response><Status>OK</Status></Response>".freeze
+  PS_URL = "https://api.xero.com/api.xro/2.0/BrandingThemes/BT-1/PaymentServices".freeze
+
+  setup do
+    @application = Xeroizer::OAuth2Application.new(
+      CLIENT_ID, CLIENT_SECRET, tenant_id: TENANT_ID, access_token: ACCESS_TOKEN
+    )
+  end
+
+  # The gem transmits write bodies as the form param `xml=<url-encoded XML>`;
+  # recover the XML document the method actually built.
+  def posted_xml(req)
+    CGI.unescape(req.body.sub(/\Axml=/, ""))
+  end
+
+  context "#add_payment_service" do
+    should "POST a <PaymentService> body with the payment service id" do
+      stub_request(:post, PS_URL).to_return(status: 200, body: OK_RESPONSE)
+
+      @application.BrandingTheme.add_payment_service(id: "BT-1", payment_service_id: "PS-1")
+
+      xml = nil
+      assert_requested(:post, PS_URL) { |req| xml = posted_xml(req); true }
+
+      doc = Nokogiri::XML(xml)
+      assert_equal "PaymentService", doc.root.name,
+        "expected a <PaymentService> root element, got: #{xml.inspect}"
+      assert_equal "PS-1", doc.at_xpath("/PaymentService/PaymentServiceID")&.text
+      # Guard against a revert to Hash#to_xml, which would wrap the body in a <hash> root.
+      refute_includes xml, "<hash>",
+        "unexpected <hash> wrapper in the request body"
+      refute_includes xml, "<?xml",
+        "request body should not carry an XML declaration"
+    end
+
+    should "forward a record-level call to the model" do
+      url = "https://api.xero.com/api.xro/2.0/BrandingThemes/BT-2/PaymentServices"
+      stub_request(:post, url).to_return(status: 200, body: OK_RESPONSE)
+
+      theme = @application.BrandingTheme.build(branding_theme_id: "BT-2")
+      theme.add_payment_service("PS-2")
+
+      xml = nil
+      assert_requested(:post, url) { |req| xml = posted_xml(req); true }
+      assert_equal "PS-2", Nokogiri::XML(xml).at_xpath("/PaymentService/PaymentServiceID")&.text
+    end
+  end
+end


### PR DESCRIPTION
`BrandingTheme#add_payment_service` built its request body with ActiveSupport's
`Hash#to_xml`, a core extension the gem never requires. Outside Rails on
ActiveSupport 7+ that raises `NameError: uninitialized constant ActiveSupport::XmlMini`,
so the gem's only `Hash#to_xml` caller couldn't run in a non-Rails host.

This rewrites the body with `Builder` (the gem's usual XML approach), dropping the
ActiveSupport-XML dependency. It also drops the spurious `<hash>` root element
`Hash#to_xml` wrapped around the payload — the body is now the documented
`<PaymentService><PaymentServiceID>…</PaymentServiceID></PaymentService>`.

Also requires `json` explicitly rather than relying on transitive loading
(used by `Base#to_json` and the connection/error JSON parsing).

Unit tests added for the request body. The only on-the-wire change is the body shape.