### PR TITLE
Finish OAuth 1.0a removal: drop leftover error classes and nonce retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raw `OAuth2::Error` for consumers running the OAuth2 client with
   `raise_errors: true`. Update any rescue chains accordingly.
   Non-429 `OAuth2::Error`s are unaffected and still propagate unchanged.
+- The `nonce_used_max_attempts` option and its reader were removed;
+  `app.nonce_used_max_attempts` now raises `NoMethodError`.
 
 ### Added
 
@@ -37,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   logging hooks now fire for 429 responses (they previously could not, because
   the `oauth2` gem raised before xeroizer's response layer ran). This keeps
   observability consistent across both `raise_errors` modes.
+
+### Removed
+
+- OAuth 1.0a transport support (#574). The `oauth` gem is no longer a dependency,
+  and `Xeroizer::OAuthConfig` / `Xeroizer::OAuthCredentials` and the OAuth1 methods
+  on `Xeroizer::OAuth` are gone. OAuth 2.0 is unaffected.
+- The OAuth 1.0a-only error classes `Xeroizer::OAuth::ConsumerKeyUnknown` and
+  `Xeroizer::OAuth::NonceUsed`, their error mappings, the nonce-reuse retry, and the
+  `nonce_used_max_attempts` option that configured it.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -606,25 +606,6 @@ When set to `true`, the library uses the `Retry-After` value from the API
 response to determine how long to wait. When set to a number, it always
 sleeps for that many seconds instead.
 
-Xero API Nonce Used
--------------------
-
-The Xero API seems to reject requests due to conflicts on occasion.
-
-By default, the library will raise a `Xeroizer::OAuth::NonceUsed`
-exception when one of these limits is exceeded.
-
-If required, the library can handle these exceptions internally by sleeping 1 second and then repeating the last request.
-You can set this option when initializing an application:
-
-```ruby
-# Sleep for 1 second and retry up to 3 times when Xero claims the nonce was used.
-client = Xeroizer::OAuth2Application.new(YOUR_OAUTH2_CLIENT_ID,
-                                         YOUR_OAUTH2_CLIENT_SECRET,
-                                         :nonce_used_max_attempts => 3)
-```
-
-
 Logging
 ---------------
 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -7,7 +7,7 @@ module Xeroizer
     extend Record::ApplicationHelper
 
     attr_reader :client, :logger, :rate_limit_sleep, :rate_limit_max_attempts,
-                :default_headers, :unitdp, :before_request, :after_request, :around_request, :nonce_used_max_attempts
+                :default_headers, :unitdp, :before_request, :after_request, :around_request
 
     attr_accessor :xero_url
 
@@ -70,7 +70,6 @@ module Xeroizer
         @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
-        @nonce_used_max_attempts = options[:nonce_used_max_attempts] || 1
         @default_headers = options[:default_headers] || {}
         @before_request = options.delete(:before_request)
         @after_request = options.delete(:after_request)

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -113,11 +113,6 @@ module Xeroizer
         after_request.call(request_info, response) if after_request
 
         HttpResponse.from_response(response, request_body, url).body
-      rescue Xeroizer::OAuth::NonceUsed => exception
-        raise if attempts > nonce_used_max_attempts
-        logger.info("Nonce used: " + exception.to_s) if self.logger
-        sleep_for(1)
-        retry
       rescue Xeroizer::OAuth::RateLimitExceeded => exception
         sleep_duration = rate_limit_sleep_duration!(exception, attempts)
         logger.warn(

--- a/lib/xeroizer/http_response.rb
+++ b/lib/xeroizer/http_response.rb
@@ -39,8 +39,6 @@ module Xeroizer
         when "token_expired"                then raise OAuth::TokenExpired.new(description)
         when "token_rejected"               then raise OAuth::TokenInvalid.new(description)
         when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
-        when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
-        when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
         when "organisation offline"         then raise OAuth::OrganisationOffline.new(description)
         else raise OAuth::UnknownError.new(problem + ':' + description)
         end

--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -20,8 +20,6 @@ module Xeroizer
     class OAuthError < XeroizerError; end
     class TokenExpired < OAuthError; end
     class TokenInvalid < OAuthError; end
-    class ConsumerKeyUnknown < OAuthError; end
-    class NonceUsed < OAuthError; end
     class OrganisationOffline < OAuthError; end
     class Forbidden < OAuthError; end
     class UnknownError < OAuthError; end

--- a/test/stub_responses/nonce_used
+++ b/test/stub_responses/nonce_used
@@ -1,1 +1,0 @@
-oauth_problem=nonce_used&oauth_problem_advice=The%20nonce%20value%20%22potatocakes%22%20has%20already%20been%20used%20

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -66,30 +66,6 @@ class HttpTest < UnitTestCase
         end
       end
 
-      context "consumer_key_unknown" do
-        setup do
-          body = "oauth_problem_advice=some more advice&oauth_problem=consumer_key_unknown"
-          stub_request(:get, @uri).to_return(status: @status_code, body: body)
-        end
-
-        should "raise an OAuth::ConsumerKeyUnknown" do
-          error = assert_raises(Xeroizer::OAuth::ConsumerKeyUnknown) { @application.http_get(@application.client, @uri) }
-          assert_equal "some more advice", error.message
-        end
-      end
-
-      context "nonce_used" do
-        setup do
-          body = get_file_as_string("nonce_used")
-          stub_request(:get, @uri).to_return(status: @status_code, body: body)
-        end
-
-        should "raise an OAuth::NonceUsed" do
-          error = assert_raises(Xeroizer::OAuth::NonceUsed) { @application.http_get(@application.client, @uri) }
-          assert_equal "The nonce value \"potatocakes\" has already been used ", error.message
-        end
-      end
-
       context "organisation offline" do
         setup do
           body = "oauth_problem_advice=organisational advice&oauth_problem=organisation offline"
@@ -550,30 +526,6 @@ class HttpTest < UnitTestCase
         should "raise an OAuth::RateLimitExceeded" do
           error = assert_raises(Xeroizer::OAuth::RateLimitExceeded) { @application.http_get(@application.client, @uri) }
           assert_equal "please wait before retrying the xero api\n", error.message
-        end
-      end
-
-      context "consumer_key_unknown" do
-        setup do
-          body = "oauth_problem_advice=some more advice&oauth_problem=consumer_key_unknown"
-          stub_request(:get, @uri).to_return(status: @status_code, body: body)
-        end
-
-        should "raise an OAuth::ConsumerKeyUnknown" do
-          error = assert_raises(Xeroizer::OAuth::ConsumerKeyUnknown) { @application.http_get(@application.client, @uri) }
-          assert_equal "some more advice", error.message
-        end
-      end
-
-      context "nonce_used" do
-        setup do
-          body = get_file_as_string("nonce_used")
-          stub_request(:get, @uri).to_return(status: @status_code, body: body)
-        end
-
-        should "raise an OAuth::NonceUsed" do
-          error = assert_raises(Xeroizer::OAuth::NonceUsed) { @application.http_get(@application.client, @uri) }
-          assert_equal "The nonce value \"potatocakes\" has already been used ", error.message
         end
       end
 


### PR DESCRIPTION
#574 removed the OAuth 1.0a transport but left OAuth1-only remnants in the error
layer. Consumer keys and nonces have no OAuth 2.0 equivalent, so this was dead code.

- Remove `OAuth::ConsumerKeyUnknown` / `OAuth::NonceUsed` and their
  `consumer_key_unknown` / `nonce_used` mappings. The `oauth_problem` parser stays —
  it's still the fallback for non-JSON error bodies and maps codes (token_expired,
  organisation offline, …) that remain in use *(I think)*.
- Remove the nonce-reuse retry loop and the `nonce_used_max_attempts` option.
- Remove the now-dead tests, the unused `nonce_used` fixture, and the stale
  "Xero API Nonce Used" README section.
- Add the missing CHANGELOG entry for the #574 transport removal.

**Breaking:** `nonce_used_max_attempts` and its reader are gone;
`app.nonce_used_max_attempts` now raises `NoMethodError`.