### PR TITLE
Fix RecordBaseTest setup choking on the utf-16-declared api_exception fixture

### DIFF
--- a/test/unit/record/base_test.rb
+++ b/test/unit/record/base_test.rb
@@ -148,7 +148,9 @@ class RecordBaseTest < Test::Unit::TestCase
 
     context 'api error received' do
       setup do
-        response = get_file_as_string('api_exception.xml')
+        # Xero declares these error bodies utf-16 but encodes them utf-8; strip the
+        # declaration so Nokogiri parses it, as XmlErrorResponse does for real responses.
+        response = get_file_as_string('api_exception.xml').sub('<?xml version="1.0" encoding="utf-16"?>', '')
         doc = Nokogiri::XML(response)
         exception = Xeroizer::ApiException.new(doc.root.xpath("Type").text,
                                                doc.root.xpath("Message").text,


### PR DESCRIPTION
`RecordBaseTest`'s "api error received" context errors in `setup` on modern
libxml2, taking down all four of its tests:

NoMethodError: undefined method `xpath' for nil  (base_test.rb:153)

The fixture `test/stub_responses/api_exception.xml` is declared
`<?xml version="1.0" encoding="utf-16"?>` but encoded UTF-8.
Modern libxml2 refuses that mismatch, so `Nokogiri::XML(response).root` is `nil`
and the setup's `doc.root.xpath("Type")` raises before the tests run. (Older,
more lenient libxml2 parsed it, so this passed historically.)

This is test-only — the library itself already handles it:
`XmlErrorResponse#raise_bad_request!` strips that declaration before parsing. The
fix makes the test setup do the same:

```ruby
response = get_file_as_string('api_exception.xml').sub('<?xml version="1.0" encoding="utf-16"?>', '')
```
RecordBaseTest now passes (15 tests, 0 failures, 0 errors).