### PR TITLE
Replace the shoulda meta-gem with shoulda-context

### DIFF
--- a/test/acceptance/bulk_operations_test.rb
+++ b/test/acceptance/bulk_operations_test.rb
@@ -1,8 +1,5 @@
 require "test_helper"
 require "acceptance_test"
-require "shoulda/matchers"
-
-include Shoulda::Matchers
 
 class BulkOperationsTest < Test::Unit::TestCase
   include AcceptanceTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require "rubygems"
 
 require 'test/unit'
 require 'mocha'
-require 'shoulda'
+require 'shoulda-context'
 require 'pp'
 
 require File.dirname(__FILE__) + '/../lib/xeroizer.rb'
@@ -59,7 +59,7 @@ module TestHelper
   end
 end
 
-Shoulda::Context::ClassMethods.class_eval do
+Shoulda::Context::DSL::ClassMethods.class_eval do
   %w{it must can}.each do |m|
     alias_method m, :should
   end

--- a/xeroizer.gemspec
+++ b/xeroizer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "mocha"
-  s.add_development_dependency "shoulda", "~> 3.6.0"
+  s.add_development_dependency "shoulda-context", "~> 2.0"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "redcarpet"
   s.add_development_dependency "yard"


### PR DESCRIPTION
The test suite only uses shoulda-context's `should`/`context` blocks, but it
depended on the `shoulda` meta-gem — which also pulled in `shoulda-matchers`.
Depend on `shoulda-context` directly and drop `shoulda-matchers`.