### PR TITLE
Add GitHub Actions CI and an ActiveSupport compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but always let master runs finish (keeps the badge accurate).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }} / AS ${{ matrix.activesupport }}
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/activesupport_${{ matrix.activesupport }}.gemfile
+    strategy:
+      fail-fast: false
+      # Minimal covering set: every supported Ruby once, every supported
+      # ActiveSupport once (AS 8.x requires Ruby >= 3.2).
+      matrix:
+        include:
+          - { ruby: '3.1', activesupport: '7.0' }
+          - { ruby: '3.2', activesupport: '7.1' }
+          - { ruby: '3.3', activesupport: '7.2' }
+          - { ruby: '3.4', activesupport: '8.0' }
+          - { ruby: '4.0', activesupport: '8.1' }
+          # Bleeding edge (next Ruby + Rails main); allowed to fail so it never reds the build.
+          - { ruby: 'ruby-head', activesupport: 'head', experimental: true }
+    continue-on-error: ${{ matrix.experimental == true }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pkg/
 .DS_Store
 .idea/
 Gemfile.lock
+gemfiles/*.lock
 tmp/
 *~
 TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: ruby
-script: bundle exec rake test:unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   logging hooks now fire for 429 responses (they previously could not, because
   the `oauth2` gem raised before xeroizer's response layer ran). This keeps
   observability consistent across both `raise_errors` modes.
-- `activesupport` now requires `>= 5.2` (previously unconstrained, which let it
-  resolve to ancient releases that fail to load on Ruby 3.2+).
+- `activesupport` now requires `>= 7.0` (previously unconstrained, which let it
+  resolve to ancient, EOL releases that fail to load on modern Ruby).
+- Minimum supported Ruby is now 3.1 (`required_ruby_version >= 3.1`); RubyGems
+  refuses to install the gem on older Rubies.
 
 ### Removed
 
@@ -66,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The gem now requires `active_support/core_ext/object/blank` and `.../object/try`
   explicitly; it used `blank?`/`present?`/`try` but only loaded them transitively,
   which broke on modern ActiveSupport outside Rails.
+- Loads ActiveSupport's deprecation framework before its core extensions,
+  preventing a load-time crash on ActiveSupport versions that emit a deprecation
+  from a cherry-picked file (e.g. 8.2).
 - `#attributes=` now raises the same clear `undefined method` error as `.build` when given an invalid attribute name. (#570)
 - Avoid an extra API call when accessing allocations from a credit note. (#554)
 - A `raw_body: true` request body is now computed once before the retry loop, so

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Xeroizer API Library
 ====================
 
+[![CI](https://github.com/waynerobinson/xeroizer/actions/workflows/ci.yml/badge.svg)](https://github.com/waynerobinson/xeroizer/actions/workflows/ci.yml)
+[![Gem Version](https://img.shields.io/gem/v/xeroizer)](https://rubygems.org/gems/xeroizer)
+
 **Homepage**: 		[http://waynerobinson.github.com/xeroizer](http://waynerobinson.github.com/xeroizer)
 
 **Git**: 					[git://github.com/waynerobinson/xeroizer.git](git://github.com/waynerobinson/xeroizer.git)

--- a/gemfiles/activesupport_7.0.gemfile
+++ b/gemfiles/activesupport_7.0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.0.0"
+
+gemspec path: "../"

--- a/gemfiles/activesupport_7.1.gemfile
+++ b/gemfiles/activesupport_7.1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.1.0"
+
+gemspec path: "../"

--- a/gemfiles/activesupport_7.2.gemfile
+++ b/gemfiles/activesupport_7.2.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.2.0"
+
+gemspec path: "../"

--- a/gemfiles/activesupport_8.0.gemfile
+++ b/gemfiles/activesupport_8.0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", "~> 8.0.0"
+
+gemspec path: "../"

--- a/gemfiles/activesupport_8.1.gemfile
+++ b/gemfiles/activesupport_8.1.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", "~> 8.1.0"
+
+gemspec path: "../"

--- a/gemfiles/activesupport_head.gemfile
+++ b/gemfiles/activesupport_head.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "activesupport", github: "rails/rails"
+
+gemspec path: "../"

--- a/lib/xeroizer.rb
+++ b/lib/xeroizer.rb
@@ -1,6 +1,14 @@
 require 'rubygems'
 require 'date'
 require 'forwardable'
+# Load the deprecation framework before cherry-picking core_ext: some versions
+# emit a deprecation at load time (e.g. AS 7.1 array, AS 8.2 time), which needs
+# ActiveSupport::Deprecation + ActiveSupport.deprecator already defined.
+require 'active_support/deprecation'
+begin
+  require 'active_support/deprecator' # added in AS 7.1; absent on 7.0, which has no load-time deprecator use
+rescue LoadError
+end
 require 'active_support/inflector'
 require "active_support/core_ext/array"
 require "active_support/core_ext/big_decimal/conversions"

--- a/xeroizer.gemspec
+++ b/xeroizer.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- test/*`.split("\n")
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = ">= 3.1"
+
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "mocha"
@@ -35,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_dependency "builder", ">= 2.1.2"
   s.add_dependency "oauth2", ">= 2.0", "< 3.0"
-  s.add_dependency "activesupport", ">= 5.2"
+  s.add_dependency "activesupport", ">= 7.0"
   s.add_dependency "nokogiri"
   s.add_dependency "tzinfo"
   s.add_dependency "i18n"


### PR DESCRIPTION
## What

Replaces the (effectively empty) Travis config with a GitHub Actions workflow that runs the unit suite across a Ruby × ActiveSupport matrix.

- **CI** (`.github/workflows/ci.yml`): runs `bundle exec rake test` (unit-only; the suite stubs all Xero HTTP, so it needs no credentials or secrets).
- **Matrix** — a minimal covering set: each supported Ruby once and each supported ActiveSupport once, pinned per-cell via `gemfiles/` + `BUNDLE_GEMFILE`:

  | Ruby | ActiveSupport |
  |------|---------------|
  | 3.1  | 7.0 |
  | 3.2  | 7.1 |
  | 3.3  | 7.2 |
  | 3.4  | 8.0 |
  | 4.0  | 8.1 |
  | ruby-head | Rails `main` *(experimental, non-blocking)* |

- **Supported versions**: sets `required_ruby_version >= 3.1` and raises the `activesupport` floor to `>= 7.0`.
- **README**: adds CI and gem-version badges.
- Removes `.travis.yml`.

## Notable: a load-time crash on some ActiveSupport versions

Building the matrix surfaced a real bug. `lib/xeroizer.rb` cherry-picks ActiveSupport core extensions (e.g. `active_support/core_ext/array`) without first loading `active_support`. Some AS versions emit a **deprecation at load time** from those files:

- AS **7.1** — `array/conversions` calls `ActiveSupport.deprecator`
- AS **8.2** (currently Rails `main`) — `time/conversions` references `ActiveSupport::Deprecation`

…both undefined unless the deprecation framework is already loaded, so `require 'xeroizer'` raises `NoMethodError` / `NameError`.

The fix loads just the deprecation framework (not all of ActiveSupport):

```ruby
require 'active_support/deprecation'
begin
  require 'active_support/deprecator' # added in AS 7.1; absent on 7.0
rescue LoadError
end
```

The `rescue LoadError` is necessary: `active_support/deprecator` only exists from AS 7.1, and `LoadError` isn't a `StandardError` (so a bare `rescue` modifier wouldn't catch it).

## Testing

All cells pass — 191 tests, 0 failures — including `ruby-head` + Rails `main`. The change touches no test files.
