### PR TITLE
Cap honored Retry-After at rate_limit_max_sleep, default 120s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mis-send request bodies.
 - `LineItem#line_item_id` is now a guid, producing `LineItemID` in XML to match Xero's case-sensitive parsing. (#562)
 - `rate_limit_sleep: true` now respects the `Retry-After` response header. (#569)
+- New `rate_limit_max_sleep` option (default 120) caps the `Retry-After` honored
+  by `rate_limit_sleep: true`; a larger value (daily limit exhausted) raises
+  `Xeroizer::OAuth::RateLimitExceeded` instead of sleeping. Pass `false` to
+  sleep uncapped. A fixed numeric `rate_limit_sleep` is never capped.
 - `rate_limit_sleep` now also works under `raise_errors: true`.
 - A numeric `rate_limit_sleep` is now clamped to a non-negative number.
   Fractional values are preserved (`2.5` sleeps 2.5 seconds). Negative values

--- a/README.md
+++ b/README.md
@@ -609,6 +609,27 @@ When set to `true`, the library uses the `Retry-After` value from the API
 response to determine how long to wait. When set to a number, it always
 sleeps for that many seconds instead.
 
+With `:rate_limit_sleep => true`, the honored `Retry-After` is capped by
+`:rate_limit_max_sleep` (default 120 seconds). A `Retry-After` above the cap
+means the daily limit is exhausted, so the library raises
+`Xeroizer::OAuth::RateLimitExceeded` instead of sleeping for hours:
+
+```ruby
+# Honor Retry-After up to 5 minutes; raise beyond that.
+client = Xeroizer::OAuth2Application.new(YOUR_OAUTH2_CLIENT_ID,
+                                         YOUR_OAUTH2_CLIENT_SECRET,
+                                         :rate_limit_sleep => true,
+                                         :rate_limit_max_sleep => 300)
+
+# Sleep for the full Retry-After, however long.
+client = Xeroizer::OAuth2Application.new(YOUR_OAUTH2_CLIENT_ID,
+                                         YOUR_OAUTH2_CLIENT_SECRET,
+                                         :rate_limit_sleep => true,
+                                         :rate_limit_max_sleep => false)
+```
+
+`:rate_limit_max_sleep` has no effect when `:rate_limit_sleep` is not `true`.
+
 Logging
 ---------------
 

--- a/lib/xeroizer/generic_application.rb
+++ b/lib/xeroizer/generic_application.rb
@@ -6,7 +6,7 @@ module Xeroizer
     include Http
     extend Record::ApplicationHelper
 
-    attr_reader :client, :logger, :rate_limit_sleep, :rate_limit_max_attempts,
+    attr_reader :client, :logger, :rate_limit_sleep, :rate_limit_max_attempts, :rate_limit_max_sleep,
                 :default_headers, :unitdp, :before_request, :after_request, :around_request
 
     attr_accessor :xero_url
@@ -70,6 +70,12 @@ module Xeroizer
         @xero_url = options[:xero_url] || "https://api.xero.com/api.xro/2.0"
         @rate_limit_sleep = options[:rate_limit_sleep] || false
         @rate_limit_max_attempts = options[:rate_limit_max_attempts] || 5
+        # Longest Retry-After honored when rate_limit_sleep is true; larger
+        # values (daily limit exhausted) raise instead of sleeping for hours.
+        # Xero's per-minute window sends Retry-After <= 60s, so 120 clears
+        # every minute-window breach. Pass false to sleep uncapped. No effect
+        # unless rate_limit_sleep is true.
+        @rate_limit_max_sleep = options.fetch(:rate_limit_max_sleep, 120)
         @default_headers = options[:default_headers] || {}
         @before_request = options.delete(:before_request)
         @after_request = options.delete(:after_request)

--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -180,7 +180,15 @@ module Xeroizer
       raise exception if attempts > rate_limit_max_attempts
 
       if self.rate_limit_sleep == true
-        (exception.retry_after && exception.retry_after > 0) ? exception.retry_after : 1
+        duration = (exception.retry_after && exception.retry_after > 0) ? exception.retry_after : 1
+
+        # A Retry-After beyond the cap means the daily limit is exhausted, not
+        # the per-minute window; raise so callers can reschedule instead of
+        # holding a thread asleep for hours. A fixed numeric rate_limit_sleep
+        # is the caller's own choice and is never capped.
+        raise exception if rate_limit_max_sleep && duration > rate_limit_max_sleep
+
+        duration
       else
         [self.rate_limit_sleep.to_f, 0].max
       end

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -346,6 +346,93 @@ class HttpTest < UnitTestCase
             assert_equal 328, error.daily_limit_remaining
           end
 
+          should "sleep and retry when retry-after is within rate_limit_max_sleep" do
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: true,
+              rate_limit_max_sleep: 90,
+              raise_errors: true
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "42",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(42)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+          end
+
+          should "raise RateLimitExceeded without sleeping when retry-after exceeds the default rate_limit_max_sleep" do
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "14400",
+                "x-daylimit-remaining" => "0",
+              }
+            )
+
+            @application.expects(:sleep_for).never
+
+            error = assert_raises(Xeroizer::OAuth::RateLimitExceeded) {
+              @application.http_get(@application.client, @uri)
+            }
+            assert_equal 14400, error.retry_after
+            assert_equal 0, error.daily_limit_remaining
+          end
+
+          should "never cap a fixed numeric rate_limit_sleep" do
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: 300,
+              raise_errors: true
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "42",
+                "x-daylimit-remaining" => "328",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(300.0)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+          end
+
+          should "sleep for the full retry-after when rate_limit_max_sleep is false" do
+            @application = Xeroizer::OAuth2Application.new(
+              CLIENT_ID, CLIENT_SECRET,
+              tenant_id: TENANT_ID, access_token: ACCESS_TOKEN,
+              rate_limit_sleep: true,
+              rate_limit_max_sleep: false,
+              raise_errors: true
+            )
+
+            stub_request(:get, @uri).to_return(
+              status: 429,
+              body: "",
+              headers: {
+                "retry-after" => "14400",
+                "x-daylimit-remaining" => "0",
+              }
+            ).then.to_return(status: 200, body: "<Response/>")
+
+            @application.expects(:sleep_for).with(14400)
+            result = @application.http_get(@application.client, @uri)
+            assert_equal "<Response/>", result
+          end
+
           should "raise RateLimitExceeded (not OAuth2::Error) when rate_limit_sleep is false" do
             @application = Xeroizer::OAuth2Application.new(
               CLIENT_ID, CLIENT_SECRET,


### PR DESCRIPTION
With `rate_limit_sleep: true` (#569), the sleep duration comes from Xero's
`Retry-After` header. Per-minute breaches send <= 60s, but a daily-limit 429
sends the seconds until the 24h window frees — potentially hours. Sleeping
that long silently pins the calling thread; callers with their own retry
scheduling (background job backoff) would rather get the exception and
reschedule.

This adds a `rate_limit_max_sleep` option: when the `Retry-After`-derived
duration exceeds the cap, `Xeroizer::OAuth::RateLimitExceeded` is raised
instead of sleeping.

- Defaults to 120s (2x the per-minute window), so `rate_limit_sleep: true`
  stays safe out of the box while still honoring every minute-window breach.
- `rate_limit_max_sleep: false` restores uncapped sleeping.
- No effect when `rate_limit_sleep` is not `true` — a fixed numeric sleep is
  the caller's own choice and is never capped.

Since the `Retry-After` support (#569) is itself still unreleased, this is an
evolution of that feature rather than a behavior break for released users;
changelogged under `[Unreleased]` / `Changed` accordingly.

Tests cover: within-cap sleep + retry, above-cap raise without sleeping,
`false` = uncapped, and the numeric-sleep exemption.